### PR TITLE
Enforce case-insensitive basename uniqueness + prompt UX

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -4,6 +4,8 @@ This file is the project’s lightweight decision log. Append entries; don’t r
 
 - 2026-02-17: Adopt **fail fast + loud** error handling. Avoid silent ignores in production code; either return/wrap errors or explicitly discard with a comment.
 - 2026-02-17: Use basename-based wiki-link resolution and backlinks; enforce basename uniqueness within a vault.
+- 2026-02-17: Basename uniqueness and wiki-link/backlink resolution are **case-insensitive** (canonical key = strings.ToLower(filepath.Base(path))).
+- 2026-02-17: UX: Errors and user-facing messages should be **front-and-center** (overlay/prompt), not only the status bar. Validation errors during prompts keep the prompt open and render the message inside the prompt.
 - 2026-02-17: Add deterministic Markdown auto-format on save (configurable via `auto_format_on_save`).
 - 2026-02-17: Normalize vault path to an absolute path at startup to avoid Neovim CWD/path double-prefix issues.
 - 2026-02-17: On Neovim buffer write, immediately re-index the saved note and refresh the info panel backlinks for the currently open note.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 - Feature request workflow + templates
 - Improve UX around fatal errors (consistent quit path, error display)
-- Vault operations: enforce basename uniqueness across all move/copy flows
+- Vault operations: enforce basename uniqueness across all move/copy flows (done)
 
 ## Later
 

--- a/internal/index/db_test.go
+++ b/internal/index/db_test.go
@@ -79,7 +79,7 @@ func TestFindNoteByBasename(t *testing.T) {
 		}
 	}()
 
-	if _, err := db.UpsertNote("projects/my-note.md", "My Note", "my-note", "", "a", 1000, 10); err != nil {
+	if _, err := db.UpsertNote("projects/My-Note.md", "My Note", "my-note", "", "a", 1000, 10); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.UpsertNote("daily/2024-01-01.md", "2024-01-01", "2024-01-01", "", "b", 1000, 10); err != nil {
@@ -93,7 +93,8 @@ func TestFindNoteByBasename(t *testing.T) {
 		basename string
 		want     string
 	}{
-		{"my-note.md", "projects/my-note.md"},
+		{"my-note.md", "projects/My-Note.md"},
+		{"MY-NOTE.MD", "projects/My-Note.md"},
 		{"2024-01-01.md", "daily/2024-01-01.md"},
 		{"root-note.md", "root-note.md"},
 		{"nonexistent.md", ""},
@@ -108,6 +109,11 @@ func TestFindNoteByBasename(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("FindNoteByBasename(%q) = %q, want %q", tt.basename, got, tt.want)
 		}
+	}
+
+	// Case-insensitive uniqueness should be enforced at the DB level.
+	if _, err := db.UpsertNote("otherdir/my-note.md", "Dup", "dup", "", "z", 1000, 10); err == nil {
+		t.Fatalf("expected duplicate basename insert to fail")
 	}
 }
 


### PR DESCRIPTION
Closes #5

### What
- Enforce vault-wide basename uniqueness as **case-insensitive** via `notes.basename_key` + unique index (with migration/backfill).
- Store/link/resolve wiki links/backlinks by canonical lowercased basename key.
- Tighten move flows to respect basename uniqueness (copy remains disallowed).
- Prompt UX: validation errors render inside the prompt and keep it open; prompt width is reasonable; overlays are ANSI-safe.

### Notes
- Migration will fail fast if the existing index contains two notes differing only by case; user must resolve the conflict and rebuild the index DB.