### PR TITLE
ci: speed up via minimal nix shell + go cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,14 +21,26 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v12
 
+      # Use GitHub Actions cache only for now (no FlakeHub auth).
       - name: Enable Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@v7
+        with:
+          use-gha-cache: true
+          use-flakehub: false
 
-      - name: Test
-        run: nix develop -c make test
+      # Cache Go module + build caches between runs.
+      - name: Cache Go
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-      - name: Lint
-        run: nix develop -c make lint
-
-      - name: Build
-        run: nix develop -c make build
+      # Use the minimal CI devShell to reduce downloads, and run everything
+      # inside a single nix develop to avoid repeated shell realization.
+      - name: Test / Lint / Build
+        run: nix develop .#ci -c bash -c "make test lint build"

--- a/flake.nix
+++ b/flake.nix
@@ -10,9 +10,21 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+
+        baseShell = { packages ? [ ], shellHookExtra ? "" }:
+          pkgs.mkShell {
+            packages = packages;
+
+            shellHook = ''
+              export CGO_ENABLED=0
+              export PATH="$PWD/bin:$PATH"
+              ${shellHookExtra}
+            '';
+          };
       in
       {
-        devShells.default = pkgs.mkShell {
+        # Full-featured dev shell for humans.
+        devShells.default = baseShell {
           packages = with pkgs; [
             go
             gnumake
@@ -22,12 +34,17 @@
             neovim
             sqlite
           ];
+          shellHookExtra = "echo \"Kopr dev shell ready\"";
+        };
 
-          shellHook = ''
-            export CGO_ENABLED=0
-            export PATH="$PWD/bin:$PATH"
-            echo "Kopr dev shell ready"
-          '';
+        # Minimal shell for CI (smaller closure => less to download).
+        devShells.ci = baseShell {
+          packages = with pkgs; [
+            go
+            gnumake
+            golangci-lint
+            sqlite
+          ];
         };
       }
     );


### PR DESCRIPTION
This PR speeds up CI without introducing a new external Nix cache provider.

Changes:
- Add `devShells.ci` (minimal closure) in `flake.nix`.
- Run test/lint/build in a single `nix develop .#ci` invocation.
- Add `actions/cache` for Go module/build + golangci-lint caches.
- Configure `magic-nix-cache-action` to use GitHub Actions cache only (`use-flakehub: false`) to avoid FlakeHub auth noise.

Future: we can add a self-hosted Attic binary cache later.