### PR TITLE
finder: hint + confirm before creating note

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -10,3 +10,4 @@ This file is the project’s lightweight decision log. Append entries; don’t r
 - 2026-02-17: Normalize vault path to an absolute path at startup to avoid Neovim CWD/path double-prefix issues.
 - 2026-02-17: On Neovim buffer write, immediately re-index the saved note and refresh the info panel backlinks for the currently open note.
 - 2026-02-17: Resizing: force a full Bubble Tea terminal repaint (`tea.ClearScreen`) on `WindowSizeMsg` to avoid persistent blank UI after terminal resizes; also signal Neovim with SIGWINCH after PTY resize.
+- 2026-02-18: Finder UX: when no results match the query, show an explicit hint that Enter will create a note and require a confirm prompt before creating; cancel returns to the finder with the query preserved.

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -114,6 +114,7 @@ func (a *App) createNoteFromFinder(name string) {
 	content := fmt.Sprintf("---\ntitle: %s\n---\n\n", name)
 	fullPath, err := a.vault.CreateNote(relPath, content)
 	if err != nil {
+		a.status.SetError(err.Error())
 		return
 	}
 


### PR DESCRIPTION
Fixes #15.

- When finder has no results, show explicit hint that Enter will create a note.
- Pressing Enter in no-results now opens a confirmation prompt.
- Cancel keeps you in the finder with the query preserved.
