### PR TITLE
lint: enable errcheck check-blank and fix all blank error discards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
   settings:
     errcheck:
       check-type-assertions: true
+      check-blank: true
   exclusions:
     rules:
       - path: ".*_test\\.go$"

--- a/cmd/kopr/main.go
+++ b/cmd/kopr/main.go
@@ -70,7 +70,10 @@ func main() {
 		fmt.Fprintln(os.Stderr, "error creating vault dir:", err)
 		os.Exit(1)
 	}
-	_ = os.MkdirAll(filepath.Join(cfg.VaultPath, ".kopr"), 0755)
+	if err := os.MkdirAll(filepath.Join(cfg.VaultPath, ".kopr"), 0755); err != nil {
+		fmt.Fprintln(os.Stderr, "error creating .kopr dir:", err)
+		os.Exit(1)
+	}
 
 	if err := editor.CheckNvimVersion(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -104,7 +107,10 @@ func main() {
 func runLocal(cfg config.Config) {
 	// Ensure lipgloss/termenv uses truecolor so extracted colorscheme colors
 	// render accurately instead of being approximated to the 256-color palette.
-	_ = os.Setenv("COLORTERM", "truecolor") // hint for termenv color profile detection
+	if err := os.Setenv("COLORTERM", "truecolor"); err != nil {
+		fmt.Fprintln(os.Stderr, "error setting COLORTERM:", err)
+		os.Exit(1)
+	}
 
 	a := app.New(cfg)
 	p := tea.NewProgram(&a, tea.WithAltScreen(), tea.WithMouseCellMotion())
@@ -125,7 +131,9 @@ func runServe(cfg config.Config) {
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sig
-		_ = s.Close()
+		if err := s.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "error closing server: %v\n", err)
+		}
 	}()
 
 	if err := s.ListenAndServe(); err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,7 +93,10 @@ func New(cfg config.Config) App {
 
 	f := panel.NewFinder()
 	store := session.NewStore(cfg.VaultPath)
-	state, _ := store.Load()
+	state, err := store.Load()
+	if err != nil {
+		state = session.Default()
+	}
 
 	a := App{
 		cfg:      cfg,
@@ -667,7 +670,8 @@ func (a *App) handleBufferWritten(path string) tea.Cmd {
 		if len(lines) > 0 && line > len(lines) {
 			line = len(lines)
 		}
-		_ = rpc.SetCursorPosition(line, col)
+		// Best-effort cursor restoration after format.
+		rpc.SetCursorPosition(line, col) //nolint:errcheck
 
 		// Write without triggering autocommands to avoid infinite loops.
 		if err := rpc.ExecCommand("noautocmd write"); err != nil {

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -235,7 +235,10 @@ func (a *App) CreateDailyNote() {
 		return
 	}
 	a.openInEditor(path)
-	rel, _ := filepath.Rel(a.cfg.VaultPath, path)
+	rel, err := filepath.Rel(a.cfg.VaultPath, path)
+	if err != nil {
+		rel = filepath.Base(path)
+	}
 	a.status.SetFile(rel)
 	a.currentFile = rel
 	a.tree.Refresh()
@@ -247,7 +250,10 @@ func (a *App) CreateInboxNote() {
 		return
 	}
 	a.openInEditor(path)
-	rel, _ := filepath.Rel(a.cfg.VaultPath, path)
+	rel, err := filepath.Rel(a.cfg.VaultPath, path)
+	if err != nil {
+		rel = filepath.Base(path)
+	}
 	a.status.SetFile(rel)
 	a.currentFile = rel
 	a.tree.Refresh()
@@ -265,7 +271,10 @@ func (a *App) InsertTemplate() {
 			return
 		}
 		a.openInEditor(path)
-		rel, _ := filepath.Rel(a.cfg.VaultPath, path)
+		rel, err := filepath.Rel(a.cfg.VaultPath, path)
+		if err != nil {
+			rel = filepath.Base(path)
+		}
 		a.status.SetFile(rel)
 		a.currentFile = rel
 		a.tree.Refresh()
@@ -311,8 +320,8 @@ func (a *App) FollowLink() {
 	basename := filepath.Base(markdown.ResolveWikiLinkTarget(link.Target))
 	targetPath := ""
 	if a.db != nil {
-		resolved, _ := a.db.FindNoteByBasename(basename)
-		if resolved != "" {
+		resolved, err := a.db.FindNoteByBasename(basename)
+		if err == nil && resolved != "" {
 			targetPath = resolved
 		}
 	}
@@ -390,12 +399,7 @@ func (a *App) ReloadConfig() {
 					a.whichKey.SetTheme(&a.theme)
 					a.editor.SetTheme(&a.theme)
 				}
-				_ = rpc.ExecCommand("hi Normal guibg=NONE")
-				_ = rpc.ExecCommand("hi NonText guibg=NONE")
-				_ = rpc.ExecCommand("hi EndOfBuffer guibg=NONE")
-				_ = rpc.ExecCommand("hi FoldColumn guibg=NONE")
-				_ = rpc.ExecCommand("hi SignColumn guibg=NONE")
-				_ = rpc.ExecCommand("hi NormalNC guibg=NONE")
+				rpc.ClearHighlightBgs()
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,10 @@ type Config struct {
 }
 
 func Default() Config {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
 	return Config{
 		VaultPath:     filepath.Join(home, "notes"),
 		Listen:        ":2222",

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -25,7 +25,10 @@ func ConfigDir() string {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, "kopr")
 	}
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
 	return filepath.Join(home, ".config", "kopr")
 }
 
@@ -84,7 +87,10 @@ func SaveFile(vaultPath string) error {
 	}
 
 	// Store with ~ for readability if under home dir.
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
 	display := vaultPath
 	if home != "" && strings.HasPrefix(vaultPath, home+string(os.PathSeparator)) {
 		display = "~" + vaultPath[len(home):]
@@ -112,7 +118,10 @@ func ExpandHome(path string) string {
 	if !strings.HasPrefix(path, "~") {
 		return path
 	}
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
 	if path == "~" {
 		return home
 	}

--- a/internal/editor/debug.go
+++ b/internal/editor/debug.go
@@ -26,5 +26,5 @@ func debugf(format string, args ...any) {
 	if debugFile == nil {
 		return
 	}
-	_, _ = fmt.Fprintf(debugFile, "%s "+format+"\n", append([]any{time.Now().Format(time.RFC3339Nano)}, args...)...)
+	fmt.Fprintf(debugFile, "%s "+format+"\n", append([]any{time.Now().Format(time.RFC3339Nano)}, args...)...) //nolint:errcheck // debug log
 }

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -420,12 +420,7 @@ func (e Editor) applyColorscheme() tea.Cmd {
 		}
 		// Clear explicit backgrounds so Neovim uses the terminal default,
 		// preserving terminal transparency.
-		_ = rpc.ExecCommand("hi Normal guibg=NONE")
-		_ = rpc.ExecCommand("hi NonText guibg=NONE")
-		_ = rpc.ExecCommand("hi EndOfBuffer guibg=NONE")
-		_ = rpc.ExecCommand("hi FoldColumn guibg=NONE")
-		_ = rpc.ExecCommand("hi SignColumn guibg=NONE")
-		_ = rpc.ExecCommand("hi NormalNC guibg=NONE")
+		rpc.ClearHighlightBgs()
 		return ColorsReadyMsg{Colors: colors}
 	}
 }

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -73,7 +73,10 @@ func (idx *Indexer) IndexFile(absPath string) error {
 
 	// Check if file has changed
 	hash := fmt.Sprintf("%x", sha256.Sum256(content))
-	existingHash, _ := idx.db.GetNoteHash(relPath)
+	existingHash, err := idx.db.GetNoteHash(relPath)
+	if err != nil {
+		existingHash = "" // treat as changed; will re-index
+	}
 	if hash == existingHash {
 		return nil // unchanged
 	}

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"database/sql"
+	"errors"
 )
 
 // SearchResult represents a single search result.
@@ -51,14 +52,12 @@ func (db *DB) Search(query string, limit int) ([]SearchResult, error) {
 	for rows.Next() {
 		var r SearchResult
 		if err := rows.Scan(&r.ID, &r.Path, &r.Title, &r.Rank); err != nil {
-			_ = rows.Close()
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		results = append(results, r)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, err
+		return nil, errors.Join(err, rows.Close())
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -88,14 +87,12 @@ func (db *DB) SearchFiles(query string, limit int) ([]SearchResult, error) {
 	for rows.Next() {
 		var r SearchResult
 		if err := rows.Scan(&r.ID, &r.Path, &r.Title, &r.Rank); err != nil {
-			_ = rows.Close()
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		results = append(results, r)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, err
+		return nil, errors.Join(err, rows.Close())
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -123,14 +120,12 @@ func (db *DB) ListAllNotes(limit int) ([]SearchResult, error) {
 	for rows.Next() {
 		var r SearchResult
 		if err := rows.Scan(&r.ID, &r.Path, &r.Title, &r.Rank); err != nil {
-			_ = rows.Close()
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		results = append(results, r)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, err
+		return nil, errors.Join(err, rows.Close())
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -157,14 +152,12 @@ func (db *DB) GetBacklinks(targetPath string) ([]BacklinkResult, error) {
 	for rows.Next() {
 		var r BacklinkResult
 		if err := rows.Scan(&r.SourcePath, &r.SourceTitle, &r.Line, &r.Col); err != nil {
-			_ = rows.Close()
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		results = append(results, r)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, err
+		return nil, errors.Join(err, rows.Close())
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -221,14 +214,12 @@ func (db *DB) SearchHeadings(query string, limit int) ([]HeadingResult, error) {
 	for rows.Next() {
 		var r HeadingResult
 		if err := rows.Scan(&r.NoteID, &r.NotePath, &r.Level, &r.Text, &r.Line); err != nil {
-			_ = rows.Close()
-			return nil, err
+			return nil, errors.Join(err, rows.Close())
 		}
 		results = append(results, r)
 	}
 	if err := rows.Err(); err != nil {
-		_ = rows.Close()
-		return nil, err
+		return nil, errors.Join(err, rows.Close())
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/index/watcher.go
+++ b/internal/index/watcher.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,8 +54,7 @@ func NewWatcher(indexer *Indexer, root string, onChange func(), onError func(err
 		}
 		return nil
 	}); err != nil {
-		_ = fw.Close()
-		return nil, err
+		return nil, errors.Join(err, fw.Close())
 	}
 
 	return w, nil

--- a/internal/panel/tree.go
+++ b/internal/panel/tree.go
@@ -94,7 +94,10 @@ func NewTree(v *vault.Vault) Tree {
 func (t *Tree) SetTheme(th *theme.Theme) { t.theme = th }
 
 func (t *Tree) Refresh() {
-	entries, _ := t.vault.ListEntries()
+	entries, err := t.vault.ListEntries()
+	if err != nil {
+		entries = nil
+	}
 	t.allEntries = entries
 	t.rebuildVisible()
 	t.pruneStale()

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -34,7 +34,10 @@ func (v *Vault) ListEntries() ([]Entry, error) {
 			return nil // skip errors
 		}
 
-		rel, _ := filepath.Rel(v.Root, path)
+		rel, err := filepath.Rel(v.Root, path)
+		if err != nil {
+			return nil
+		}
 		if rel == "." {
 			return nil
 		}


### PR DESCRIPTION
## Summary
- Enable `check-blank: true` in errcheck so `_ = err` patterns are flagged by the linter
- Replace ~30 blank error discards across 15 files with proper handling: `errors.Join` for cleanup-on-failure, explicit fallbacks for non-critical calls, `//nolint:errcheck` for intentionally ignored errors (shutdown, cosmetic, debug)
- Add `ClearHighlightBgs()` method to consolidate 12 duplicate highlight-clear calls into 2 call sites

## Test plan
- [x] `make build` compiles
- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] `make test-integration` passes
- [x] `grep '_ = .*err'` returns no matches

Closes #26