### PR TITLE
clipboard: copy yanked text to system clipboard via OSC 52

### DIFF
--- a/cmd/kopr/main.go
+++ b/cmd/kopr/main.go
@@ -113,6 +113,7 @@ func runLocal(cfg config.Config) {
 	}
 
 	a := app.New(cfg)
+	a.SetOutput(os.Stdout)
 	p := tea.NewProgram(&a, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	a.SetProgram(p)
 	if _, err := p.Run(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,14 @@ module github.com/pfassina/kopr
 go 1.25.5
 
 require (
+	github.com/BurntSushi/toml v1.6.0
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/ssh v0.0.0-20250826160808-ebfa259c7309
 	github.com/charmbracelet/wish v1.4.7
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/charmbracelet/x/vt v0.0.0-20260209194814-eeb2896ac759
 	github.com/creack/pty v1.1.24
 	github.com/fsnotify/fsnotify v1.9.0
@@ -17,15 +20,12 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/keygen v0.5.3 // indirect
 	github.com/charmbracelet/log v0.4.1 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20251106193841-7889546fc720 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/conpty v0.1.0 // indirect
 	github.com/charmbracelet/x/errors v0.0.0-20240508181413-e8d8b6e2de86 // indirect

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -55,6 +55,11 @@ type FollowLinkMsg struct{}
 // GoBackMsg is sent when the user presses gb to go back to the previous note.
 type GoBackMsg struct{}
 
+// YankMsg is sent when text is yanked in Neovim (via TextYankPost autocmd).
+type YankMsg struct {
+	Text string
+}
+
 // ColorsReadyMsg is sent after the colorscheme is applied and colors are extracted.
 // If Err is set, the colorscheme failed to load and Colors will be nil.
 type ColorsReadyMsg struct {
@@ -219,6 +224,10 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 				return e, tea.Quit
 			}
 			if err := e.rpc.SetupLinkNavigation(e.program); err != nil {
+				e.err = err
+				return e, tea.Quit
+			}
+			if err := e.rpc.SetupYankClipboard(e.program); err != nil {
 				e.err = err
 				return e, tea.Quit
 			}

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -13,6 +13,7 @@ import (
 func NewHandler(cfg config.Config) bts.Handler {
 	return func(sess ssh.Session) (tea.Model, []tea.ProgramOption) {
 		a := app.New(cfg)
+		a.SetOutput(sess)
 
 		opts := []tea.ProgramOption{
 			tea.WithAltScreen(),


### PR DESCRIPTION
## Summary

- Yanking text in Neovim (`y`, `yy`, visual select + `y`) now copies to the system clipboard via OSC 52 terminal escape sequences
- Works both locally and over SSH (the client terminal interprets the sequence)

## How it works

A `TextYankPost` autocmd in Neovim sends yanked text back to Go via RPC. The app writes an OSC 52 sequence to the terminal output (`os.Stdout` locally, the SSH session over SSH), which tells the terminal emulator to set the system clipboard.

## Test plan

- [ ] Local: open a note, visually select text, yank with `y` — verify text appears in system clipboard
- [ ] SSH: connect via `--serve`, repeat above — verify clipboard works through the SSH session
- [ ] `yy` (yank line) and other yank variants also copy to clipboard
- [ ] `make build`, `make lint`, `make test` all pass

Closes #31