### PR TITLE
info: collapsible sections with backlinks, outgoing links, and outline

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -89,7 +89,7 @@ func (a *App) navigateTo(relPath string) {
 	a.status.ClearError()
 	a.status.SetFile(relPath)
 	a.currentFile = relPath
-	a.updateBacklinks(relPath)
+	a.updateInfoPanel(relPath)
 }
 
 func New(cfg config.Config) App {
@@ -301,6 +301,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.updateWhichKey()
 		}
 
+	case panel.InfoGotoLineMsg:
+		rpc := a.editor.GetRPC()
+		if rpc != nil {
+			rpc.SetCursorPosition(msg.Line, 0) //nolint:errcheck // best-effort cursor jump
+		}
+		a.setFocus(focusEditor)
+		return a, nil
+
 	case panel.FileSelectedMsg:
 		a.navigateTo(msg.Path)
 		a.setFocus(focusEditor)
@@ -388,7 +396,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// If the user saved the currently open note, refresh backlinks in-place.
 		if msg.relPath != "" && msg.relPath == a.currentFile {
-			a.updateBacklinks(a.currentFile)
+			a.updateInfoPanel(a.currentFile)
 		}
 		return a, nil
 
@@ -865,7 +873,7 @@ func (a *App) handleSaveAsPrompt(value string, closeAfter bool) (cmd tea.Cmd, ok
 	a.status.SetFile(relPath)
 	a.currentFile = relPath
 	a.tree.Refresh()
-	a.updateBacklinks(relPath)
+	a.updateInfoPanel(relPath)
 
 	if closeAfter {
 		a.showSplash()

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -129,25 +129,46 @@ func (a *App) createNoteFromFinder(name string) {
 	a.tree.Refresh()
 }
 
-// updateBacklinks refreshes the backlinks panel for the given note path.
-func (a *App) updateBacklinks(relPath string) {
+// updateInfoPanel refreshes all info panel sections for the given note path.
+func (a *App) updateInfoPanel(relPath string) {
 	if a.db == nil {
 		return
 	}
 
+	// Backlinks
 	backlinks, err := a.db.GetBacklinks(relPath)
-	if err != nil || len(backlinks) == 0 {
-		a.info.SetBacklinks(nil)
-		return
+	if err != nil {
+		backlinks = nil
 	}
-
-	items := make([]panel.InfoItem, len(backlinks))
+	blItems := make([]panel.InfoItem, len(backlinks))
 	for i, bl := range backlinks {
 		title := bl.SourceTitle
 		if title == "" {
 			title = bl.SourcePath
 		}
-		items[i] = panel.InfoItem{Title: title, Path: bl.SourcePath}
+		blItems[i] = panel.InfoItem{Title: title, Path: bl.SourcePath}
 	}
-	a.info.SetBacklinks(items)
+	a.info.SetBacklinks(blItems)
+
+	// Outgoing links
+	outgoing, err := a.db.GetOutgoingLinks(relPath)
+	if err != nil {
+		outgoing = nil
+	}
+	olItems := make([]panel.InfoItem, len(outgoing))
+	for i, ol := range outgoing {
+		olItems[i] = panel.InfoItem{Title: ol.TargetTitle, Path: ol.TargetPath}
+	}
+	a.info.SetOutgoingLinks(olItems)
+
+	// Outline (headings)
+	headings, err := a.db.GetHeadingsForNote(relPath)
+	if err != nil {
+		headings = nil
+	}
+	hdItems := make([]panel.InfoItem, len(headings))
+	for i, h := range headings {
+		hdItems[i] = panel.InfoItem{Title: h.Text, Line: h.Line, Level: h.Level}
+	}
+	a.info.SetOutline(hdItems)
 }

--- a/internal/app/keymap.go
+++ b/internal/app/keymap.go
@@ -89,7 +89,7 @@ func newBindings() map[string]*Binding {
 					a.ToggleTree()
 					return nil
 				}},
-				"b": {Key: "b", Label: "Toggle backlinks", Action: func(a *App) tea.Cmd {
+				"b": {Key: "b", Label: "Toggle info", Action: func(a *App) tea.Cmd {
 					a.ToggleInfo()
 					return nil
 				}},

--- a/internal/editor/rpc.go
+++ b/internal/editor/rpc.go
@@ -397,6 +397,8 @@ func (r *RPC) ExtractColors() (map[string][2]string, error) {
 		"NonText", "LineNr", "WinSeparator",
 		"StatusLine", "DiagnosticError",
 		"String", "Visual", "WarningMsg",
+		"@markup.heading.1.markdown", "@markup.heading.2.markdown",
+		"markdownH1", "markdownH2",
 	}
 
 	result := make(map[string][2]string, len(groups))

--- a/internal/index/db_test.go
+++ b/internal/index/db_test.go
@@ -153,3 +153,175 @@ func TestBacklinks(t *testing.T) {
 		t.Errorf("backlink source: got %q, want %q", backlinks[0].SourcePath, "a.md")
 	}
 }
+
+func TestGetOutgoingLinks(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	idA, err := db.UpsertNote("a.md", "Note A", "a", "", "a", 1000, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idB, err := db.UpsertNote("b.md", "Note B", "b", "", "b", 1000, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolved link: a -> b (target_id set via direct SQL since InsertLink doesn't set it)
+	if err := db.InsertLink(idA, "b.md", "", "", 3, 0); err != nil {
+		t.Fatal(err)
+	}
+	// Manually resolve the link's target_id
+	if _, err := db.conn.Exec("UPDATE links SET target_id = ? WHERE source_id = ? AND target_path = ?", idB, idA, "b.md"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unresolved link: a -> nonexistent
+	if err := db.InsertLink(idA, "nonexistent.md", "", "", 5, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := db.GetOutgoingLinks("a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 outgoing links, got %d", len(results))
+	}
+
+	// First link: resolved
+	if results[0].TargetTitle != "Note B" {
+		t.Errorf("first link title: got %q, want %q", results[0].TargetTitle, "Note B")
+	}
+	if !results[0].Resolved {
+		t.Error("first link should be resolved")
+	}
+
+	// Second link: unresolved (falls back to target_path)
+	if results[1].TargetTitle != "nonexistent.md" {
+		t.Errorf("second link title: got %q, want %q", results[1].TargetTitle, "nonexistent.md")
+	}
+	if results[1].Resolved {
+		t.Error("second link should not be resolved")
+	}
+}
+
+func TestGetOutgoingLinksEmpty(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if _, err := db.UpsertNote("a.md", "Note A", "a", "", "a", 1000, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := db.GetOutgoingLinks("a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 outgoing links, got %d", len(results))
+	}
+}
+
+func TestGetHeadingsForNote(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	id, err := db.UpsertNote("a.md", "Note A", "a", "", "a", 1000, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.InsertHeading(id, 1, "Introduction", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InsertHeading(id, 2, "Details", 5); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.InsertHeading(id, 3, "Sub-details", 10); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := db.GetHeadingsForNote("a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("expected 3 headings, got %d", len(results))
+	}
+
+	if results[0].Text != "Introduction" || results[0].Level != 1 || results[0].Line != 1 {
+		t.Errorf("heading 0: got %+v", results[0])
+	}
+	if results[1].Text != "Details" || results[1].Level != 2 || results[1].Line != 5 {
+		t.Errorf("heading 1: got %+v", results[1])
+	}
+	if results[2].Text != "Sub-details" || results[2].Level != 3 || results[2].Line != 10 {
+		t.Errorf("heading 2: got %+v", results[2])
+	}
+}
+
+func TestGetHeadingsForNoteEmpty(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if _, err := db.UpsertNote("a.md", "Note A", "a", "", "a", 1000, 10); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := db.GetHeadingsForNote("a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 headings, got %d", len(results))
+	}
+}
+
+func TestGetHeadingsForNoteNonexistent(t *testing.T) {
+	db, err := OpenMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	results, err := db.GetHeadingsForNote("nonexistent.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 headings for nonexistent note, got %d", len(results))
+	}
+}

--- a/internal/index/search.go
+++ b/internal/index/search.go
@@ -30,6 +30,13 @@ type HeadingResult struct {
 	Line     int
 }
 
+// OutgoingLinkResult represents an outgoing link from a note.
+type OutgoingLinkResult struct {
+	TargetPath  string
+	TargetTitle string
+	Resolved    bool
+}
+
 // Search performs a full-text search across notes.
 func (db *DB) Search(query string, limit int) ([]SearchResult, error) {
 	if limit <= 0 {
@@ -189,6 +196,75 @@ func (db *DB) GetNoteIDByPath(path string) (int64, error) {
 		return 0, nil
 	}
 	return id, err
+}
+
+// GetOutgoingLinks returns all links from the given note.
+// Resolved links include the target note's title; unresolved links fall back to target_path.
+func (db *DB) GetOutgoingLinks(relPath string) ([]OutgoingLinkResult, error) {
+	noteID, err := db.GetNoteIDByPath(relPath)
+	if err != nil || noteID == 0 {
+		return nil, err
+	}
+
+	rows, err := db.conn.Query(`
+		SELECT l.target_path, COALESCE(n.title, ''), l.target_id IS NOT NULL
+		FROM links l
+		LEFT JOIN notes n ON n.id = l.target_id
+		WHERE l.source_id = ?
+		ORDER BY l.line, l.col
+	`, noteID)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []OutgoingLinkResult
+	for rows.Next() {
+		var r OutgoingLinkResult
+		if err := rows.Scan(&r.TargetPath, &r.TargetTitle, &r.Resolved); err != nil {
+			return nil, errors.Join(err, rows.Close())
+		}
+		if r.TargetTitle == "" {
+			r.TargetTitle = r.TargetPath
+		}
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Join(err, rows.Close())
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// GetHeadingsForNote returns all headings for a specific note, ordered by line.
+func (db *DB) GetHeadingsForNote(relPath string) ([]HeadingResult, error) {
+	rows, err := db.conn.Query(`
+		SELECT h.note_id, n.path, h.level, h.text, h.line
+		FROM headings h
+		JOIN notes n ON n.id = h.note_id
+		WHERE n.path = ?
+		ORDER BY h.line
+	`, relPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []HeadingResult
+	for rows.Next() {
+		var r HeadingResult
+		if err := rows.Scan(&r.NoteID, &r.NotePath, &r.Level, &r.Text, &r.Line); err != nil {
+			return nil, errors.Join(err, rows.Close())
+		}
+		results = append(results, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Join(err, rows.Close())
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 // SearchHeadings searches headings across all notes.

--- a/internal/panel/info.go
+++ b/internal/panel/info.go
@@ -1,6 +1,7 @@
 package panel
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -9,22 +10,52 @@ import (
 	"github.com/pfassina/kopr/internal/theme"
 )
 
+// InfoGotoLineMsg is emitted when the user presses enter on an outline heading.
+type InfoGotoLineMsg struct {
+	Line int
+}
+
 // InfoItem represents an item in the info panel.
 type InfoItem struct {
 	Title string
 	Path  string
+	Line  int
+	Level int
 }
 
-// Info is the info/backlinks panel.
+// section represents a collapsible section in the info panel.
+type section struct {
+	title     string
+	items     []InfoItem
+	collapsed bool
+	emptyMsg  string
+}
+
+// flatRowKind distinguishes section headers from items in the flat list.
+type flatRowKind int
+
+const (
+	rowHeader flatRowKind = iota
+	rowItem
+	rowSeparator // blank line between sections, not selectable
+)
+
+// flatRow is a single row in the virtual flat list.
+type flatRow struct {
+	kind       flatRowKind
+	sectionIdx int
+	itemIdx    int // only valid when kind == rowItem
+}
+
+// Info is the info panel with collapsible sections.
 type Info struct {
-	width   int
-	height  int
-	title   string
-	items   []InfoItem
-	cursor  int
-	offset  int
-	focused bool
-	theme   *theme.Theme
+	width    int
+	height   int
+	sections [3]section
+	cursor   int
+	offset   int
+	focused  bool
+	theme    *theme.Theme
 }
 
 // SetTheme sets the color theme for the info panel.
@@ -32,31 +63,77 @@ func (i *Info) SetTheme(th *theme.Theme) { i.theme = th }
 
 func NewInfo() Info {
 	return Info{
-		title: "Info",
+		sections: [3]section{
+			{title: "Backlinks", emptyMsg: "No backlinks"},
+			{title: "Outgoing Links", emptyMsg: "No outgoing links"},
+			{title: "Outline", emptyMsg: "No headings"},
+		},
 	}
 }
 
 func (i *Info) SetBacklinks(items []InfoItem) {
-	i.title = "Backlinks"
-	i.items = items
-	i.cursor = 0
-	i.offset = 0
+	i.sections[0].items = items
+	i.clampCursor()
 }
 
-func (i *Info) SetOutline(headings []string) {
-	i.title = "Outline"
-	i.items = make([]InfoItem, len(headings))
-	for j, h := range headings {
-		i.items[j] = InfoItem{Title: h}
+func (i *Info) SetOutgoingLinks(items []InfoItem) {
+	i.sections[1].items = items
+	i.clampCursor()
+}
+
+func (i *Info) SetOutline(items []InfoItem) {
+	i.sections[2].items = items
+	i.clampCursor()
+}
+
+func (i *Info) Clear() {
+	for idx := range i.sections {
+		i.sections[idx].items = nil
 	}
 	i.cursor = 0
 	i.offset = 0
 }
 
-func (i *Info) Clear() {
-	i.items = nil
-	i.cursor = 0
-	i.offset = 0
+// flatList builds the virtual flat list from sections.
+func (i Info) flatList() []flatRow {
+	var rows []flatRow
+	for si := range i.sections {
+		if si > 0 {
+			rows = append(rows, flatRow{kind: rowSeparator})
+		}
+		rows = append(rows, flatRow{kind: rowHeader, sectionIdx: si})
+		if !i.sections[si].collapsed {
+			for ii := range i.sections[si].items {
+				rows = append(rows, flatRow{kind: rowItem, sectionIdx: si, itemIdx: ii})
+			}
+		}
+	}
+	return rows
+}
+
+func (i *Info) clampCursor() {
+	rows := i.flatList()
+	if len(rows) == 0 {
+		i.cursor = 0
+		i.offset = 0
+		return
+	}
+	if i.cursor >= len(rows) {
+		i.cursor = len(rows) - 1
+	}
+	if i.cursor < 0 {
+		i.cursor = 0
+	}
+	// Skip separators
+	for i.cursor < len(rows) && rows[i.cursor].kind == rowSeparator {
+		i.cursor++
+	}
+	if i.cursor >= len(rows) {
+		i.cursor = len(rows) - 1
+		for i.cursor > 0 && rows[i.cursor].kind == rowSeparator {
+			i.cursor--
+		}
+	}
 }
 
 func (i Info) Update(msg tea.Msg) (Info, tea.Cmd) {
@@ -66,46 +143,110 @@ func (i Info) Update(msg tea.Msg) (Info, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		viewHeight := i.height - 2
-		if viewHeight < 1 {
-			viewHeight = 1
+		rows := i.flatList()
+		if len(rows) == 0 {
+			return i, nil
 		}
+
+		viewHeight := i.viewHeight()
+
 		switch msg.String() {
 		case "j", "down":
-			if i.cursor < len(i.items)-1 {
-				i.cursor++
+			next := i.cursor + 1
+			// Skip separators
+			for next < len(rows) && rows[next].kind == rowSeparator {
+				next++
+			}
+			if next < len(rows) {
+				i.cursor = next
 				if i.cursor-i.offset >= viewHeight {
-					i.offset++
+					i.offset = i.cursor - viewHeight + 1
 				}
 			}
 		case "k", "up":
-			if i.cursor > 0 {
-				i.cursor--
+			prev := i.cursor - 1
+			// Skip separators
+			for prev >= 0 && rows[prev].kind == rowSeparator {
+				prev--
+			}
+			if prev >= 0 {
+				i.cursor = prev
 				if i.cursor < i.offset {
 					i.offset = i.cursor
 				}
 			}
 		case "enter":
-			if i.cursor < len(i.items) {
-				item := i.items[i.cursor]
-				if item.Path != "" {
-					return i, func() tea.Msg {
-						return FileSelectedMsg{Path: item.Path}
+			if i.cursor < len(rows) {
+				row := rows[i.cursor]
+				if row.kind == rowHeader {
+					i.sections[row.sectionIdx].collapsed = !i.sections[row.sectionIdx].collapsed
+					i.clampCursor()
+				} else {
+					item := i.sections[row.sectionIdx].items[row.itemIdx]
+					if item.Path != "" {
+						return i, func() tea.Msg {
+							return FileSelectedMsg{Path: item.Path}
+						}
+					}
+					if item.Line > 0 {
+						return i, func() tea.Msg {
+							return InfoGotoLineMsg{Line: item.Line}
+						}
 					}
 				}
 			}
 		case "G":
-			i.cursor = len(i.items) - 1
+			i.cursor = len(rows) - 1
+			for i.cursor > 0 && rows[i.cursor].kind == rowSeparator {
+				i.cursor--
+			}
 			if i.cursor-i.offset >= viewHeight {
 				i.offset = i.cursor - viewHeight + 1
 			}
 		case "g":
 			i.cursor = 0
+			for i.cursor < len(rows)-1 && rows[i.cursor].kind == rowSeparator {
+				i.cursor++
+			}
 			i.offset = 0
+		case "tab", "}":
+			i.jumpSection(rows, 1)
+		case "shift+tab", "{":
+			i.jumpSection(rows, -1)
 		}
 	}
 
 	return i, nil
+}
+
+// jumpSection moves the cursor to the next or previous section header.
+func (i *Info) jumpSection(rows []flatRow, dir int) {
+	if len(rows) == 0 {
+		return
+	}
+	pos := i.cursor + dir
+	for pos >= 0 && pos < len(rows) {
+		if rows[pos].kind == rowHeader {
+			i.cursor = pos
+			i.scrollIntoView()
+			return
+		}
+		pos += dir
+	}
+}
+
+func (i *Info) scrollIntoView() {
+	viewHeight := i.viewHeight()
+	if i.cursor < i.offset {
+		i.offset = i.cursor
+	}
+	if i.cursor-i.offset >= viewHeight {
+		i.offset = i.cursor - viewHeight + 1
+	}
+}
+
+func (i Info) viewHeight() int {
+	return max(i.height-2, 1) // -1 for title row, -1 for bottom padding
 }
 
 func (i Info) View() string {
@@ -114,7 +255,11 @@ func (i Info) View() string {
 	}
 
 	th := i.theme
+	rows := i.flatList()
 
+	var b strings.Builder
+
+	// Panel title
 	var titleStyle lipgloss.Style
 	if i.focused {
 		titleStyle = lipgloss.NewStyle().
@@ -128,46 +273,98 @@ func (i Info) View() string {
 			Foreground(th.Dim).
 			Padding(0, 1)
 	}
-
-	var b strings.Builder
-	b.WriteString(titleStyle.Render(i.title))
+	b.WriteString(titleStyle.Render("Info"))
 	b.WriteByte('\n')
 
-	viewHeight := i.height - 2
-	if viewHeight < 0 {
-		viewHeight = 0
+	viewHeight := i.viewHeight()
+	end := min(i.offset+viewHeight, len(rows))
+
+	for idx := i.offset; idx < end; idx++ {
+		row := rows[idx]
+		switch row.kind {
+		case rowSeparator:
+			b.WriteByte('\n')
+			continue
+		case rowHeader:
+			b.WriteString(i.renderHeader(row.sectionIdx, idx == i.cursor))
+		case rowItem:
+			item := i.sections[row.sectionIdx].items[row.itemIdx]
+			b.WriteString(i.renderItem(item, row.sectionIdx, idx == i.cursor))
+		}
+		b.WriteByte('\n')
 	}
 
-	if len(i.items) == 0 {
+	// If all sections are empty and nothing rendered, show a dim message.
+	if len(rows) == 0 {
 		dim := lipgloss.NewStyle().Foreground(th.Dim).Padding(0, 1)
 		b.WriteString(dim.Render("No items"))
 		b.WriteByte('\n')
-	} else {
-		for j := i.offset; j < len(i.items) && j-i.offset < viewHeight; j++ {
-			line := i.items[j].Title
-			if len(line) > i.width-2 {
-				line = line[:i.width-5] + "..."
-			}
-
-			// Pad to width
-			padded := " " + line
-			if len(padded) < i.width-2 {
-				padded += strings.Repeat(" ", i.width-2-len(padded))
-			}
-
-			if j == i.cursor && i.focused {
-				style := lipgloss.NewStyle().
-					Foreground(th.Accent).
-					Bold(true)
-				b.WriteString(style.Render(padded))
-			} else {
-				b.WriteString(padded)
-			}
-			b.WriteByte('\n')
-		}
 	}
 
 	return b.String()
+}
+
+func (i Info) renderHeader(sectionIdx int, selected bool) string {
+	th := i.theme
+	sec := i.sections[sectionIdx]
+
+	indicator := "▾"
+	if sec.collapsed {
+		indicator = "▸"
+	}
+
+	text := fmt.Sprintf("%s %s (%d)", indicator, sec.title, len(sec.items))
+
+	// Pad to width
+	padded := " " + text
+	if len(padded) < i.width-2 {
+		padded += strings.Repeat(" ", i.width-2-len(padded))
+	}
+
+	if selected && i.focused {
+		return lipgloss.NewStyle().
+			Foreground(th.Accent2).
+			Bold(true).
+			Render(padded)
+	}
+
+	style := lipgloss.NewStyle().Bold(true)
+	if i.focused {
+		style = style.Foreground(th.Accent)
+	} else {
+		style = style.Foreground(th.Dim)
+	}
+	return style.Render(padded)
+}
+
+func (i Info) renderItem(item InfoItem, sectionIdx int, selected bool) string {
+	th := i.theme
+
+	title := item.Title
+	indent := "   "
+	// Outline items get extra indentation by heading level.
+	if sectionIdx == 2 && item.Level > 1 {
+		indent += strings.Repeat("  ", item.Level-1)
+	}
+
+	line := indent + title
+	maxW := i.width - 2
+	if len(line) > maxW && maxW > 3 {
+		line = line[:maxW-3] + "..."
+	}
+
+	// Pad to width
+	if len(line) < maxW {
+		line += strings.Repeat(" ", maxW-len(line))
+	}
+
+	if selected && i.focused {
+		style := lipgloss.NewStyle().
+			Foreground(th.Accent2).
+			Bold(true)
+		return style.Render(line)
+	}
+	return line
 }
 
 func (i *Info) SetSize(width, height int) {

--- a/internal/panel/info_test.go
+++ b/internal/panel/info_test.go
@@ -1,0 +1,327 @@
+package panel
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/pfassina/kopr/internal/theme"
+)
+
+func newTestInfo(backlinks, outgoing, outline []InfoItem) Info {
+	info := NewInfo()
+	th := theme.DefaultTheme()
+	info.SetTheme(&th)
+	info.SetSize(40, 20)
+	info.SetFocused(true)
+	info.SetBacklinks(backlinks)
+	info.SetOutgoingLinks(outgoing)
+	info.SetOutline(outline)
+	return info
+}
+
+func key(k string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+}
+
+func specialKey(t tea.KeyType) tea.KeyMsg {
+	return tea.KeyMsg{Type: t}
+}
+
+func TestInfoFlatList(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		[]InfoItem{{Title: "ol1", Path: "b.md"}, {Title: "ol2", Path: "c.md"}},
+		[]InfoItem{{Title: "H1", Line: 1, Level: 1}},
+	)
+
+	rows := info.flatList()
+	// 3 headers + 2 separators + 1 + 2 + 1 items = 9
+	if len(rows) != 9 {
+		t.Fatalf("expected 9 rows, got %d", len(rows))
+	}
+
+	// Row layout: header0, item, sep, header1, item, item, sep, header2, item
+	if rows[0].kind != rowHeader || rows[0].sectionIdx != 0 {
+		t.Error("row 0 should be backlinks header")
+	}
+	if rows[1].kind != rowItem || rows[1].sectionIdx != 0 {
+		t.Error("row 1 should be backlink item")
+	}
+	if rows[2].kind != rowSeparator {
+		t.Error("row 2 should be separator")
+	}
+	if rows[3].kind != rowHeader || rows[3].sectionIdx != 1 {
+		t.Error("row 3 should be outgoing header")
+	}
+	if rows[7].kind != rowHeader || rows[7].sectionIdx != 2 {
+		t.Error("row 7 should be outline header")
+	}
+}
+
+func TestInfoCursorNavigation(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		[]InfoItem{{Title: "H1", Line: 1, Level: 1}},
+	)
+
+	// Initial cursor at 0 (Backlinks header)
+	if info.cursor != 0 {
+		t.Fatalf("cursor should start at 0, got %d", info.cursor)
+	}
+
+	// Move down to backlink item
+	info, _ = info.Update(key("j"))
+	if info.cursor != 1 {
+		t.Fatalf("cursor should be 1 after j, got %d", info.cursor)
+	}
+
+	// Move down again — should skip separator and land on Outgoing header
+	info, _ = info.Update(key("j"))
+	rows := info.flatList()
+	if rows[info.cursor].kind != rowHeader || rows[info.cursor].sectionIdx != 1 {
+		t.Fatalf("cursor should skip separator to Outgoing header, cursor=%d", info.cursor)
+	}
+
+	// Move up — should skip separator back to backlink item
+	info, _ = info.Update(key("k"))
+	if info.cursor != 1 {
+		t.Fatalf("cursor should skip separator back to item, got %d", info.cursor)
+	}
+
+	// Move to top
+	info, _ = info.Update(key("g"))
+	if info.cursor != 0 {
+		t.Fatalf("cursor should be 0 after g, got %d", info.cursor)
+	}
+
+	// Move to bottom — should land on last non-separator row
+	info, _ = info.Update(key("G"))
+	if rows[info.cursor].kind == rowSeparator {
+		t.Fatalf("G should not land on separator, cursor=%d", info.cursor)
+	}
+	// Last row is the outline item
+	if rows[info.cursor].kind != rowItem || rows[info.cursor].sectionIdx != 2 {
+		t.Fatalf("G should land on outline item, cursor=%d, kind=%d", info.cursor, rows[info.cursor].kind)
+	}
+}
+
+func TestInfoCollapseExpand(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}, {Title: "bl2", Path: "b.md"}},
+		nil,
+		nil,
+	)
+
+	rowsBefore := info.flatList()
+	// 3 headers + 2 separators + 2 items = 7
+	if len(rowsBefore) != 7 {
+		t.Fatalf("expected 7 rows before collapse, got %d", len(rowsBefore))
+	}
+
+	// Cursor is on backlinks header (row 0); press enter to collapse
+	info, _ = info.Update(key("enter"))
+	rowsAfter := info.flatList()
+	// 3 headers + 2 separators + 0 items (collapsed) = 5
+	if len(rowsAfter) != 5 {
+		t.Fatalf("expected 5 rows after collapse, got %d", len(rowsAfter))
+	}
+
+	// Press enter again to expand
+	info, _ = info.Update(key("enter"))
+	rowsExpanded := info.flatList()
+	if len(rowsExpanded) != 7 {
+		t.Fatalf("expected 7 rows after expand, got %d", len(rowsExpanded))
+	}
+}
+
+func TestInfoEnterOnBacklinkItem(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		nil,
+	)
+
+	// Move cursor to item (row 1)
+	info, _ = info.Update(key("j"))
+	var cmd tea.Cmd
+	_, cmd = info.Update(key("enter"))
+
+	if cmd == nil {
+		t.Fatal("expected a command on enter for backlink item")
+	}
+	msg := cmd()
+	fileMsg, ok := msg.(FileSelectedMsg)
+	if !ok {
+		t.Fatalf("expected FileSelectedMsg, got %T", msg)
+	}
+	if fileMsg.Path != "a.md" {
+		t.Errorf("path: got %q, want %q", fileMsg.Path, "a.md")
+	}
+}
+
+func TestInfoEnterOnOutlineItem(t *testing.T) {
+	info := newTestInfo(
+		nil,
+		nil,
+		[]InfoItem{{Title: "Heading 1", Line: 5, Level: 1}},
+	)
+
+	// Navigate to the outline item using j (separators are skipped automatically)
+	// Row layout: header0, sep, header1, sep, header2, item
+	// j skips sep to land on headers, then items
+	for {
+		rows := info.flatList()
+		row := rows[info.cursor]
+		if row.kind == rowItem && row.sectionIdx == 2 {
+			break
+		}
+		info, _ = info.Update(key("j"))
+	}
+
+	var cmd tea.Cmd
+	_, cmd = info.Update(key("enter"))
+	if cmd == nil {
+		t.Fatal("expected a command on enter for outline item")
+	}
+	msg := cmd()
+	gotoMsg, ok := msg.(InfoGotoLineMsg)
+	if !ok {
+		t.Fatalf("expected InfoGotoLineMsg, got %T", msg)
+	}
+	if gotoMsg.Line != 5 {
+		t.Errorf("line: got %d, want 5", gotoMsg.Line)
+	}
+}
+
+func TestInfoTabJumpsSections(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}, {Title: "bl2", Path: "b.md"}},
+		[]InfoItem{{Title: "ol1", Path: "c.md"}},
+		[]InfoItem{{Title: "H1", Line: 1, Level: 1}},
+	)
+
+	// Start at row 0 (Backlinks header)
+	if info.cursor != 0 {
+		t.Fatalf("cursor should start at 0, got %d", info.cursor)
+	}
+
+	// Tab to next section header
+	info, _ = info.Update(specialKey(tea.KeyTab))
+	rows := info.flatList()
+	if rows[info.cursor].kind != rowHeader || rows[info.cursor].sectionIdx != 1 {
+		t.Fatalf("tab should jump to Outgoing Links header, cursor=%d", info.cursor)
+	}
+
+	// Tab again to Outline header
+	info, _ = info.Update(specialKey(tea.KeyTab))
+	if rows[info.cursor].kind != rowHeader || rows[info.cursor].sectionIdx != 2 {
+		t.Fatalf("tab should jump to Outline header, cursor=%d", info.cursor)
+	}
+
+	// Shift+tab back to Outgoing Links
+	info, _ = info.Update(specialKey(tea.KeyShiftTab))
+	if rows[info.cursor].kind != rowHeader || rows[info.cursor].sectionIdx != 1 {
+		t.Fatalf("shift+tab should jump back to Outgoing Links header, cursor=%d", info.cursor)
+	}
+}
+
+func TestInfoBraceJumpsSections(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		[]InfoItem{{Title: "H1", Line: 1, Level: 1}},
+	)
+
+	// } should jump to next header
+	info, _ = info.Update(key("}"))
+	rows := info.flatList()
+	if rows[info.cursor].kind != rowHeader || rows[info.cursor].sectionIdx != 1 {
+		t.Fatalf("} should jump to Outgoing Links header, cursor=%d", info.cursor)
+	}
+
+	// { should jump back
+	info, _ = info.Update(key("{"))
+	if rows[info.cursor].kind != rowHeader || rows[info.cursor].sectionIdx != 0 {
+		t.Fatalf("{ should jump back to Backlinks header, cursor=%d", info.cursor)
+	}
+}
+
+func TestInfoClearPreservesCollapseState(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		nil,
+	)
+
+	// Collapse backlinks section
+	info, _ = info.Update(key("enter"))
+	if !info.sections[0].collapsed {
+		t.Fatal("backlinks should be collapsed")
+	}
+
+	// Clear resets items but check that collapse state is separate
+	info.Clear()
+	// After clear, items are nil but structure remains
+	if info.sections[0].items != nil {
+		t.Fatal("items should be nil after clear")
+	}
+}
+
+func TestInfoCollapseStatePreservedAcrossSetBacklinks(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		nil,
+	)
+
+	// Collapse backlinks
+	info, _ = info.Update(key("enter"))
+	if !info.sections[0].collapsed {
+		t.Fatal("backlinks should be collapsed")
+	}
+
+	// Set new backlinks data — collapse state should persist
+	info.SetBacklinks([]InfoItem{{Title: "bl2", Path: "x.md"}, {Title: "bl3", Path: "y.md"}})
+	if !info.sections[0].collapsed {
+		t.Fatal("collapse state should persist across SetBacklinks")
+	}
+}
+
+func TestInfoEmptySections(t *testing.T) {
+	info := newTestInfo(nil, nil, nil)
+
+	rows := info.flatList()
+	// 3 headers + 2 separators = 5
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows (headers + separators), got %d", len(rows))
+	}
+}
+
+func TestInfoUnfocusedIgnoresKeys(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		nil,
+	)
+	info.SetFocused(false)
+
+	info, _ = info.Update(key("j"))
+	if info.cursor != 0 {
+		t.Fatal("unfocused info should not respond to keys")
+	}
+}
+
+func TestInfoViewNonEmpty(t *testing.T) {
+	info := newTestInfo(
+		[]InfoItem{{Title: "bl1", Path: "a.md"}},
+		nil,
+		[]InfoItem{{Title: "H1", Line: 1, Level: 1}, {Title: "H2", Line: 5, Level: 2}},
+	)
+
+	view := info.View()
+	if view == "" {
+		t.Fatal("view should not be empty")
+	}
+}

--- a/internal/panel/tree.go
+++ b/internal/panel/tree.go
@@ -451,7 +451,7 @@ func (t Tree) View() string {
 
 		if i == t.cursor && t.focused {
 			style := lipgloss.NewStyle().
-				Foreground(th.Accent).
+				Foreground(th.Accent2).
 				Bold(true)
 			b.WriteString(marker + style.Render(line))
 		} else {

--- a/internal/theme/extract.go
+++ b/internal/theme/extract.go
@@ -24,6 +24,19 @@ func FromExtracted(colors map[string][2]string, base Theme) Theme {
 		t.Accent = lipgloss.Color(c)
 	}
 
+	// Accent2: derive from markdown heading highlights (treesitter → legacy fallback).
+	// H2 is preferred over H1 since H1 often matches Function/Keyword (= Accent).
+	switch {
+	case isSet(fg(colors, "@markup.heading.2.markdown")):
+		t.Accent2 = lipgloss.Color(fg(colors, "@markup.heading.2.markdown"))
+	case isSet(fg(colors, "markdownH2")):
+		t.Accent2 = lipgloss.Color(fg(colors, "markdownH2"))
+	case isSet(fg(colors, "@markup.heading.1.markdown")):
+		t.Accent2 = lipgloss.Color(fg(colors, "@markup.heading.1.markdown"))
+	case isSet(fg(colors, "markdownH1")):
+		t.Accent2 = lipgloss.Color(fg(colors, "markdownH1"))
+	}
+
 	if c := fg(colors, "Comment"); isSet(c) {
 		t.Subtle = lipgloss.Color(c)
 	}

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -8,6 +8,7 @@ import "github.com/charmbracelet/lipgloss"
 type Theme struct {
 	Bg         lipgloss.Color
 	Accent     lipgloss.Color
+	Accent2    lipgloss.Color
 	Subtle     lipgloss.Color
 	Text       lipgloss.Color
 	Dim        lipgloss.Color
@@ -26,6 +27,7 @@ func DefaultTheme() Theme {
 	return Theme{
 		Bg:         lipgloss.Color("#1e1e2e"),
 		Accent:     lipgloss.Color("#cba6f7"),
+		Accent2:    lipgloss.Color("#89b4fa"),
 		Subtle:     lipgloss.Color("#6c7086"),
 		Text:       lipgloss.Color("#cdd6f4"),
 		Dim:        lipgloss.Color("#585b70"),


### PR DESCRIPTION
## Summary

Closes #32.

- Replace flat backlinks-only info panel with a multi-section collapsible container (Backlinks, Outgoing Links, Outline)
- Add `GetOutgoingLinks` and `GetHeadingsForNote` DB queries
- Add cursor navigation (`j`/`k`), section jumping (`tab`/`shift+tab`, `{`/`}`), collapse/expand (`enter`), and outline heading jump (`enter` on heading emits `InfoGotoLineMsg`)
- Add secondary accent color (`Accent2`) derived from markdown heading highlight groups for cursor selection in tree and info panels
- Add "Info" panel title with accent highlight when focused

## Test plan

- [x] `make build` compiles
- [x] `make test` passes (new DB query tests + info panel navigation tests)
- [x] `make lint` clean
- [ ] Manual: open a note with links and headings, verify all three sections populate, collapse/expand, tab between sections, navigate to linked notes, jump to outline headings