### PR TITLE
math: render LaTeX equations as Unicode in markdown notes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -106,7 +106,7 @@ func New(cfg config.Config) App {
 
 	a := App{
 		cfg:      cfg,
-		editor:   editor.New(cfg.VaultPath, editor.ProfileMode(cfg.NvimMode), cfg.Colorscheme),
+		editor:   editor.New(cfg.VaultPath, editor.ProfileMode(cfg.NvimMode), cfg.Colorscheme, cfg.RenderMath),
 		tree:     t,
 		info:     panel.NewInfo(),
 		status:   panel.NewStatus(cfg.VaultPath),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,9 @@ type Config struct {
 
 	// AutoFormatOnSave enables Kopr's deterministic Markdown formatter after save.
 	AutoFormatOnSave bool
+
+	// RenderMath enables LaTeX math rendering via render-markdown.nvim's latex module.
+	RenderMath bool
 }
 
 func Default() Config {
@@ -45,5 +48,6 @@ func Default() Config {
 		LeaderTimeout:    500,
 		NvimMode:         "managed",
 		AutoFormatOnSave: true,
+		RenderMath:       true,
 	}
 }

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -18,6 +18,7 @@ type fileConfig struct {
 	LeaderKey         *string `toml:"leader_key"`
 	LeaderTimeout     *int    `toml:"leader_timeout"`
 	AutoFormatOnSave  *bool   `toml:"auto_format_on_save"`
+	RenderMath        *bool   `toml:"render_math"`
 }
 
 // ConfigDir returns the kopr config directory, respecting XDG_CONFIG_HOME.
@@ -74,6 +75,9 @@ func LoadFile(cfg *Config) (bool, error) {
 	}
 	if fc.AutoFormatOnSave != nil {
 		cfg.AutoFormatOnSave = *fc.AutoFormatOnSave
+	}
+	if fc.RenderMath != nil {
+		cfg.RenderMath = *fc.RenderMath
 	}
 
 	return true, nil

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -87,6 +87,7 @@ nvim_mode = "user"
 leader_key = ","
 leader_timeout = 300
 auto_format_on_save = false
+render_math = false
 `
 	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -123,6 +124,9 @@ auto_format_on_save = false
 	}
 	if cfg.AutoFormatOnSave != false {
 		t.Errorf("AutoFormatOnSave = %v, want %v", cfg.AutoFormatOnSave, false)
+	}
+	if cfg.RenderMath != false {
+		t.Errorf("RenderMath = %v, want %v", cfg.RenderMath, false)
 	}
 }
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -76,6 +76,7 @@ type Editor struct {
 	socketPath  string
 	profileMode ProfileMode
 	colorscheme string
+	renderMath  bool
 	theme       *theme.Theme
 	nvim        *nvimPTY
 	rpc         *RPC
@@ -91,11 +92,12 @@ type Editor struct {
 // SetTheme sets the color theme for the editor splash screen.
 func (e *Editor) SetTheme(th *theme.Theme) { e.theme = th }
 
-func New(vaultPath string, profileMode ProfileMode, colorscheme string) Editor {
+func New(vaultPath string, profileMode ProfileMode, colorscheme string, renderMath bool) Editor {
 	return Editor{
 		vaultPath:   vaultPath,
 		profileMode: profileMode,
 		colorscheme: colorscheme,
+		renderMath:  renderMath,
 		mode:        ModeNormal,
 		focused:     true,
 		showSplash:  true,
@@ -234,6 +236,11 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 		}
 		// Ensure left gutter aligns buffer text with panel titles
 		if err := e.rpc.ExecCommand("set foldcolumn=1"); err != nil {
+			e.err = err
+			return e, tea.Quit
+		}
+		// Configure math rendering
+		if err := e.rpc.SetupMathRendering(e.renderMath); err != nil {
 			e.err = err
 			return e, tea.Quit
 		}

--- a/internal/editor/kopr_latex.sh
+++ b/internal/editor/kopr_latex.sh
@@ -1,0 +1,153 @@
+#!/bin/sh
+# kopr-latex: LaTeX to Unicode converter for render-markdown.nvim
+# Reads LaTeX from stdin (without $ delimiters), writes Unicode to stdout.
+#
+# Uses awk for proper \command tokenisation — each backslash-letter sequence
+# is looked up in a symbol table. Unknown commands pass through unchanged.
+
+exec awk '
+BEGIN {
+  # Greek lowercase
+  s["alpha"]="α"; s["beta"]="β"; s["gamma"]="γ"; s["delta"]="δ"; s["epsilon"]="ε"
+  s["zeta"]="ζ"; s["eta"]="η"; s["theta"]="θ"; s["iota"]="ι"; s["kappa"]="κ"
+  s["lambda"]="λ"; s["mu"]="μ"; s["nu"]="ν"; s["xi"]="ξ"; s["pi"]="π"
+  s["rho"]="ρ"; s["sigma"]="σ"; s["tau"]="τ"; s["upsilon"]="υ"; s["phi"]="φ"
+  s["chi"]="χ"; s["psi"]="ψ"; s["omega"]="ω"; s["varepsilon"]="ε"; s["varphi"]="φ"
+
+  # Greek uppercase
+  s["Gamma"]="Γ"; s["Delta"]="Δ"; s["Theta"]="Θ"; s["Lambda"]="Λ"; s["Xi"]="Ξ"
+  s["Pi"]="Π"; s["Sigma"]="Σ"; s["Phi"]="Φ"; s["Psi"]="Ψ"; s["Omega"]="Ω"
+
+  # Operators
+  s["times"]="×"; s["div"]="÷"; s["pm"]="±"; s["mp"]="∓"; s["cdot"]="·"
+  s["star"]="⋆"; s["circ"]="∘"; s["bullet"]="∙"; s["oplus"]="⊕"; s["otimes"]="⊗"
+
+  # Relations
+  s["leq"]="≤"; s["geq"]="≥"; s["neq"]="≠"; s["approx"]="≈"; s["equiv"]="≡"
+  s["sim"]="∼"; s["simeq"]="≃"; s["cong"]="≅"; s["propto"]="∝"
+  s["ll"]="≪"; s["gg"]="≫"; s["le"]="≤"; s["ge"]="≥"; s["ne"]="≠"
+
+  # Arrows
+  s["rightarrow"]="→"; s["leftarrow"]="←"; s["leftrightarrow"]="↔"
+  s["Rightarrow"]="⇒"; s["Leftarrow"]="⇐"; s["Leftrightarrow"]="⇔"
+  s["uparrow"]="↑"; s["downarrow"]="↓"; s["mapsto"]="↦"; s["to"]="→"
+  s["implies"]="⟹"; s["iff"]="⟺"
+
+  # Set theory
+  s["in"]="∈"; s["notin"]="∉"; s["subset"]="⊂"; s["supset"]="⊃"
+  s["subseteq"]="⊆"; s["supseteq"]="⊇"; s["cup"]="∪"; s["cap"]="∩"
+  s["emptyset"]="∅"; s["varnothing"]="∅"
+
+  # Calculus and big operators
+  s["int"]="∫"; s["iint"]="∬"; s["iiint"]="∭"; s["oint"]="∮"
+  s["sum"]="∑"; s["prod"]="∏"; s["coprod"]="∐"
+  s["partial"]="∂"; s["nabla"]="∇"
+
+  # Logic
+  s["forall"]="∀"; s["exists"]="∃"; s["nexists"]="∄"; s["neg"]="¬"
+  s["land"]="∧"; s["lor"]="∨"; s["lnot"]="¬"
+
+  # Misc
+  s["infty"]="∞"; s["infinity"]="∞"
+  s["sqrt"]="√"; s["cbrt"]="∛"
+  s["angle"]="∠"; s["triangle"]="△"
+  s["ldots"]="…"; s["cdots"]="⋯"; s["vdots"]="⋮"; s["ddots"]="⋱"
+  s["langle"]="⟨"; s["rangle"]="⟩"
+  s["lceil"]="⌈"; s["rceil"]="⌉"; s["lfloor"]="⌊"; s["rfloor"]="⌋"
+  s["ell"]="ℓ"; s["hbar"]="ℏ"; s["Re"]="ℜ"; s["Im"]="ℑ"; s["wp"]="℘"
+  s["aleph"]="ℵ"
+
+  # Commands to remove silently
+  s["left"]=""; s["right"]=""; s["quad"]=" "; s["qquad"]="  "
+  s["frac"]=""; s["text"]=""; s["mathrm"]=""; s["mathbf"]=""; s["mathit"]=""
+
+  # Superscript digits
+  sup["0"]="⁰"; sup["1"]="¹"; sup["2"]="²"; sup["3"]="³"; sup["4"]="⁴"
+  sup["5"]="⁵"; sup["6"]="⁶"; sup["7"]="⁷"; sup["8"]="⁸"; sup["9"]="⁹"
+  sup["n"]="ⁿ"; sup["i"]="ⁱ"; sup["+"]="⁺"; sup["-"]="⁻"
+
+  # Subscript digits
+  lo["0"]="₀"; lo["1"]="₁"; lo["2"]="₂"; lo["3"]="₃"; lo["4"]="₄"
+  lo["5"]="₅"; lo["6"]="₆"; lo["7"]="₇"; lo["8"]="₈"; lo["9"]="₉"
+  lo["a"]="ₐ"; lo["e"]="ₑ"; lo["i"]="ᵢ"; lo["n"]="ₙ"; lo["x"]="ₓ"
+  lo["+"]="₊"; lo["-"]="₋"
+}
+
+# Convert a string using a character map (sup or sub)
+function to_script(str, map,    i, c, out) {
+  out = ""
+  for (i = 1; i <= length(str); i++) {
+    c = substr(str, i, 1)
+    out = out (c in map ? map[c] : c)
+  }
+  return out
+}
+
+{
+  # Phase 1: replace \command sequences via symbol table
+  result = ""
+  rest = $0
+  while (match(rest, /\\[a-zA-Z]+/)) {
+    result = result substr(rest, 1, RSTART - 1)
+    cmd = substr(rest, RSTART + 1, RLENGTH - 1)
+    if (cmd in s)
+      result = result s[cmd]
+    else
+      result = result substr(rest, RSTART, RLENGTH)
+    rest = substr(rest, RSTART + RLENGTH)
+  }
+  result = result rest
+
+  # Phase 2: \frac{a}{b} → a/b (handled after command replacement
+  # since \frac was replaced by "" leaving {a}{b})
+  while (match(result, /\{[^}]*\}\{[^}]*\}/)) {
+    # Only convert if this looks like it was a frac (preceded by nothing special)
+    pre = substr(result, 1, RSTART - 1)
+    body = substr(result, RSTART, RLENGTH)
+    post = substr(result, RSTART + RLENGTH)
+    # Extract the two groups
+    if (match(body, /^\{([^}]*)\}\{([^}]*)\}$/)) {
+      a = substr(body, 2, index(body, "}{") - 2)
+      b_start = index(body, "}{") + 2
+      b = substr(body, b_start, length(body) - b_start)
+      result = pre a "/" b post
+    } else {
+      break
+    }
+  }
+
+  # Phase 3: superscripts ^{...} and ^x
+  while (match(result, /\^{[^}]*}/)) {
+    pre = substr(result, 1, RSTART - 1)
+    body = substr(result, RSTART + 2, RLENGTH - 3)
+    post = substr(result, RSTART + RLENGTH)
+    result = pre to_script(body, sup) post
+  }
+  while (match(result, /\^[0-9a-zA-Z]/)) {
+    pre = substr(result, 1, RSTART - 1)
+    c = substr(result, RSTART + 1, 1)
+    post = substr(result, RSTART + 2)
+    result = pre (c in sup ? sup[c] : "^" c) post
+  }
+
+  # Phase 4: subscripts _{...} and _x
+  while (match(result, /_{[^}]*}/)) {
+    pre = substr(result, 1, RSTART - 1)
+    body = substr(result, RSTART + 2, RLENGTH - 3)
+    post = substr(result, RSTART + RLENGTH)
+    result = pre to_script(body, lo) post
+  }
+  while (match(result, /_[0-9a-zA-Z]/)) {
+    pre = substr(result, 1, RSTART - 1)
+    c = substr(result, RSTART + 1, 1)
+    post = substr(result, RSTART + 2)
+    result = pre (c in lo ? lo[c] : "_" c) post
+  }
+
+  # Phase 5: strip remaining braces used for grouping
+  gsub(/{/, "", result)
+  gsub(/}/, "", result)
+
+  print result
+}
+'

--- a/internal/editor/nvim_init.lua
+++ b/internal/editor/nvim_init.lua
@@ -69,6 +69,8 @@ vim.api.nvim_create_autocmd("FileType", {
 })
 
 -- Render-markdown plugin (live markdown preview via conceal)
+-- LaTeX math rendering uses the kopr-latex shell converter deployed by Kopr.
+-- Kopr reconfigures this via RPC based on the render_math config toggle.
 pcall(function()
     require("render-markdown").setup({
         render_modes = { "n", "v", "i", "c" },
@@ -81,6 +83,10 @@ pcall(function()
                 scope_highlight = 'RenderMarkdownWikiLink',
             },
         },
+        -- LaTeX math rendering is handled by Kopr's own renderer (via RPC)
+        -- rather than render-markdown.nvim's built-in latex handler, which
+        -- requires a treesitter latex parser we don't ship.
+        latex = { enabled = false },
     })
     -- Pad callout rendered text so the overlay fully covers the raw [!TAG] text.
     -- Nerd font icons are 1 cell wide, making the overlay 1 char too short and

--- a/internal/editor/profile.go
+++ b/internal/editor/profile.go
@@ -13,6 +13,9 @@ import (
 //go:embed nvim_init.lua
 var defaultInitLua []byte
 
+//go:embed kopr_latex.sh
+var latexConverterSh []byte
+
 type ProfileMode string
 
 const (
@@ -37,6 +40,11 @@ func ConfigDir() (string, error) {
 // In managed mode, writes init.lua if it doesn't exist.
 // In user mode, logs a warning if the directory doesn't exist.
 func EnsureProfile(mode ProfileMode) error {
+	// Deploy LaTeX converter script (needed regardless of profile mode)
+	if err := ensureLatexConverter(); err != nil {
+		return err
+	}
+
 	dir, err := ConfigDir()
 	if err != nil {
 		return err
@@ -218,11 +226,36 @@ func parseSemver(s string) (int, int, error) {
 	return major, minor, nil
 }
 
+// ensureLatexConverter writes the embedded LaTeX converter script to the
+// kopr bin directory so Neovim can use it as a shell command.
+func ensureLatexConverter() error {
+	dataDir, err := DataDir()
+	if err != nil {
+		return err
+	}
+	binDir := filepath.Join(dataDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return fmt.Errorf("create bin dir: %w", err)
+	}
+	dest := filepath.Join(binDir, "kopr-latex")
+	if err := os.WriteFile(dest, latexConverterSh, 0755); err != nil {
+		return fmt.Errorf("write kopr-latex: %w", err)
+	}
+	return nil
+}
+
 // NvimEnv returns environment variables for the managed Neovim process.
 func NvimEnv() []string {
-	return []string{
+	env := []string{
 		"NVIM_APPNAME=kopr",
 		"TERM=xterm-256color",
 		"COLORTERM=truecolor",
 	}
+	// Prepend kopr bin directory to PATH so the latex converter is available.
+	dataDir, err := DataDir()
+	if err == nil {
+		binDir := filepath.Join(dataDir, "bin")
+		env = append(env, "PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+	return env
 }

--- a/internal/editor/rpc.go
+++ b/internal/editor/rpc.go
@@ -449,6 +449,159 @@ func (r *RPC) ClearHighlightBgs() {
 	}
 }
 
+// SetupMathRendering installs a custom math renderer that finds latex_block
+// nodes in the built-in markdown_inline treesitter tree, converts them via the
+// kopr-latex shell script, and overlays the result using Neovim extmarks.
+// This avoids requiring the external latex treesitter parser.
+// When enabled is false, any existing math rendering is torn down.
+func (r *RPC) SetupMathRendering(enabled bool) error {
+	return r.client.ExecLua(mathRenderingLua, nil, enabled)
+}
+
+const mathRenderingLua = `
+local enabled = ...
+
+-- Disable render-markdown.nvim's built-in latex handler (it requires a
+-- treesitter latex parser we don't ship). We handle math ourselves below.
+local rm_ok, rm_state = pcall(require, 'render-markdown.state')
+if rm_ok and rm_state and rm_state.config then
+  if not rm_state.config.latex then rm_state.config.latex = {} end
+  rm_state.config.latex.enabled = false
+end
+
+local group = 'KoprMath'
+vim.api.nvim_create_augroup(group, {clear = true})
+
+if not enabled then return end
+if vim.fn.executable('kopr-latex') ~= 1 then return end
+
+local ns = vim.api.nvim_create_namespace('kopr-math')
+local conv_cache = {}
+
+local function convert(input)
+  if conv_cache[input] ~= nil then return conv_cache[input] end
+  local result = vim.system({'kopr-latex'}, {stdin = input, text = true}):wait()
+  if result.code == 0 and result.stdout then
+    local out = vim.trim(result.stdout)
+    if out ~= '' then conv_cache[input] = out; return out end
+  end
+  conv_cache[input] = false
+  return false
+end
+
+-- render_math renders all math in buf, skipping nodes that touch skip_row
+-- so the cursor line shows raw LaTeX instead of both raw + virtual text.
+local function render_math(buf, skip_row)
+  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+
+  local ok, parser = pcall(vim.treesitter.get_parser, buf, 'markdown')
+  if not ok then return end
+  parser:parse(true)
+
+  local nodes = {}
+  parser:for_each_tree(function(tree, lang_tree)
+    if lang_tree:lang() ~= 'markdown_inline' then return end
+    local function walk(node)
+      if node:type() == 'latex_block' then
+        nodes[#nodes + 1] = node
+        return
+      end
+      for i = 0, node:child_count() - 1 do walk(node:child(i)) end
+    end
+    walk(tree:root())
+  end)
+
+  for _, node in ipairs(nodes) do
+    local sr, sc, er, ec = node:range()
+
+    -- Skip nodes on the cursor line so raw LaTeX is visible for editing
+    if skip_row and skip_row >= sr and skip_row <= er then
+      goto continue
+    end
+
+    local text = vim.treesitter.get_node_text(node, buf)
+    local inner = text:match('^%$%$%s*(.-)%s*%$%$$') or text:match('^%$(.-)%$$')
+    if not inner or inner == '' then goto continue end
+    inner = vim.trim(inner)
+
+    local converted = convert(inner)
+    if not converted then goto continue end
+
+    if sr == er then
+      -- Inline math: conceal original, show converted inline
+      vim.api.nvim_buf_set_extmark(buf, ns, sr, sc, {
+        end_row = er, end_col = ec,
+        conceal = '',
+        virt_text = {{converted, 'RenderMarkdownMath'}},
+        virt_text_pos = 'inline',
+      })
+    else
+      -- Block math: conceal all lines, show converted as virtual lines
+      for r = sr, er do
+        local line = vim.api.nvim_buf_get_lines(buf, r, r + 1, false)[1] or ''
+        vim.api.nvim_buf_set_extmark(buf, ns, r, 0, {
+          end_row = r, end_col = #line, conceal = '',
+        })
+      end
+      local vlines = {}
+      for ln in converted:gmatch('[^\n]+') do
+        vlines[#vlines + 1] = {{ln, 'RenderMarkdownMath'}}
+      end
+      if #vlines > 0 then
+        vim.api.nvim_buf_set_extmark(buf, ns, sr, 0, {
+          virt_lines = vlines, virt_lines_above = true,
+        })
+      end
+    end
+    ::continue::
+  end
+end
+
+local last_cursor_row = -1
+
+local function scheduled_render(buf, skip_row)
+  vim.schedule(function()
+    if vim.api.nvim_buf_is_valid(buf) then
+      render_math(buf, skip_row)
+    end
+  end)
+end
+
+vim.api.nvim_create_autocmd(
+  {'BufEnter', 'TextChanged', 'InsertLeave'},
+  {
+    group = group,
+    pattern = '*.md',
+    callback = function(args)
+      if not vim.api.nvim_buf_is_valid(args.buf) then return end
+      if vim.bo[args.buf].filetype ~= 'markdown' then return end
+      last_cursor_row = vim.api.nvim_win_get_cursor(0)[1] - 1
+      scheduled_render(args.buf, last_cursor_row)
+    end,
+  }
+)
+
+-- Re-render when cursor moves to a different line (reveal raw on cursor line)
+vim.api.nvim_create_autocmd('CursorMoved', {
+  group = group,
+  pattern = '*.md',
+  callback = function(args)
+    if not vim.api.nvim_buf_is_valid(args.buf) then return end
+    local row = vim.api.nvim_win_get_cursor(0)[1] - 1
+    if row == last_cursor_row then return end
+    last_cursor_row = row
+    render_math(args.buf, row)
+  end,
+})
+
+-- Render the current buffer immediately if it's markdown
+local buf = vim.api.nvim_get_current_buf()
+if vim.bo[buf].filetype == 'markdown' then
+  last_cursor_row = vim.api.nvim_win_get_cursor(0)[1] - 1
+  scheduled_render(buf, last_cursor_row)
+end
+`
+
 // Close closes the RPC connection.
 func (r *RPC) Close() error {
 	if r.client != nil {


### PR DESCRIPTION
## Summary

- Renders inline (`$...$`) and block (`$$...$$`) LaTeX math as Unicode symbols in markdown notes
- Uses treesitter's built-in `markdown_inline` parser to find `latex_block` nodes — no external treesitter parsers needed
- Bundles `kopr-latex`, an awk-based converter script handling Greek letters, operators, relations, arrows, set theory, calculus symbols, super/subscripts, and `\frac`
- Overlays converted text via Neovim extmarks with conceal + inline virtual text; reveals raw LaTeX on the cursor line for editing
- Adds `render_math` config toggle (defaults to `true`), configurable in `config.toml`
- Disables render-markdown.nvim's built-in latex handler (which requires a latex treesitter parser we don't ship)

Closes #6

## Test plan

- [x] `make test` passes (config parsing tests cover new `render_math` field)
- [x] `make lint` passes with 0 issues
- [ ] Open a note containing `$\alpha + \beta$` and `$$\sum_{i=1}^{n} x_i$$` — verify Unicode rendering
- [ ] Move cursor to a math line — verify raw LaTeX is revealed
- [ ] Set `render_math = false` in `config.toml` — verify raw LaTeX is shown everywhere
- [ ] Run `kopr --reset-nvim-config` — verify init.lua includes `latex = { enabled = false }`