### PR TITLE
syntax: enable treesitter highlighting for fenced code blocks

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -106,7 +106,7 @@ func New(cfg config.Config) App {
 
 	a := App{
 		cfg:      cfg,
-		editor:   editor.New(cfg.VaultPath, editor.ProfileMode(cfg.NvimMode), cfg.Colorscheme, cfg.RenderMath),
+		editor:   editor.New(cfg.VaultPath, editor.ProfileMode(cfg.NvimMode), cfg.Colorscheme, cfg.RenderMath, cfg.TreesitterParsers),
 		tree:     t,
 		info:     panel.NewInfo(),
 		status:   panel.NewStatus(cfg.VaultPath),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,12 @@ type Config struct {
 
 	// RenderMath enables LaTeX math rendering via render-markdown.nvim's latex module.
 	RenderMath bool
+
+	// TreesitterParsers is a path to a directory containing compiled treesitter
+	// parser .so files (e.g. ~/.local/share/nvim/site). When set, Kopr adds this
+	// to Neovim's runtimepath so fenced code blocks get syntax highlighting for
+	// languages beyond those bundled with Neovim.
+	TreesitterParsers string
 }
 
 func Default() Config {

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -17,8 +17,9 @@ type fileConfig struct {
 	NvimMode          *string `toml:"nvim_mode"`
 	LeaderKey         *string `toml:"leader_key"`
 	LeaderTimeout     *int    `toml:"leader_timeout"`
-	AutoFormatOnSave  *bool   `toml:"auto_format_on_save"`
-	RenderMath        *bool   `toml:"render_math"`
+	AutoFormatOnSave    *bool   `toml:"auto_format_on_save"`
+	RenderMath          *bool   `toml:"render_math"`
+	TreesitterParsers   *string `toml:"treesitter_parsers"`
 }
 
 // ConfigDir returns the kopr config directory, respecting XDG_CONFIG_HOME.
@@ -78,6 +79,9 @@ func LoadFile(cfg *Config) (bool, error) {
 	}
 	if fc.RenderMath != nil {
 		cfg.RenderMath = *fc.RenderMath
+	}
+	if fc.TreesitterParsers != nil {
+		cfg.TreesitterParsers = ExpandHome(*fc.TreesitterParsers)
 	}
 
 	return true, nil

--- a/internal/config/file_test.go
+++ b/internal/config/file_test.go
@@ -88,6 +88,7 @@ leader_key = ","
 leader_timeout = 300
 auto_format_on_save = false
 render_math = false
+treesitter_parsers = "~/.local/share/nvim/site"
 `
 	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0644); err != nil {
 		t.Fatal(err)
@@ -127,6 +128,10 @@ render_math = false
 	}
 	if cfg.RenderMath != false {
 		t.Errorf("RenderMath = %v, want %v", cfg.RenderMath, false)
+	}
+	wantParsers := filepath.Join(home, ".local", "share", "nvim", "site")
+	if cfg.TreesitterParsers != wantParsers {
+		t.Errorf("TreesitterParsers = %q, want %q", cfg.TreesitterParsers, wantParsers)
 	}
 }
 

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -75,8 +75,9 @@ type Editor struct {
 	vaultPath   string
 	socketPath  string
 	profileMode ProfileMode
-	colorscheme string
-	renderMath  bool
+	colorscheme        string
+	renderMath         bool
+	treesitterParsers  string
 	theme       *theme.Theme
 	nvim        *nvimPTY
 	rpc         *RPC
@@ -92,15 +93,16 @@ type Editor struct {
 // SetTheme sets the color theme for the editor splash screen.
 func (e *Editor) SetTheme(th *theme.Theme) { e.theme = th }
 
-func New(vaultPath string, profileMode ProfileMode, colorscheme string, renderMath bool) Editor {
+func New(vaultPath string, profileMode ProfileMode, colorscheme string, renderMath bool, treesitterParsers string) Editor {
 	return Editor{
-		vaultPath:   vaultPath,
-		profileMode: profileMode,
-		colorscheme: colorscheme,
-		renderMath:  renderMath,
-		mode:        ModeNormal,
-		focused:     true,
-		showSplash:  true,
+		vaultPath:         vaultPath,
+		profileMode:       profileMode,
+		colorscheme:       colorscheme,
+		renderMath:        renderMath,
+		treesitterParsers: treesitterParsers,
+		mode:              ModeNormal,
+		focused:           true,
+		showSplash:        true,
 	}
 }
 
@@ -114,7 +116,7 @@ func (e Editor) Init() tea.Cmd {
 
 // start spawns Neovim and returns resources via message.
 func (e Editor) start() tea.Cmd {
-	width, height, vaultPath, profileMode := e.width, e.height, e.vaultPath, e.profileMode
+	width, height, vaultPath, profileMode, tsParsers := e.width, e.height, e.vaultPath, e.profileMode, e.treesitterParsers
 	return func() tea.Msg {
 		if err := EnsureProfile(profileMode); err != nil {
 			return editorErrorMsg{fmt.Errorf("nvim profile: %w", err)}
@@ -125,7 +127,7 @@ func (e Editor) start() tea.Cmd {
 			return editorErrorMsg{fmt.Errorf("remove socket %s: %w", socketPath, err)}
 		}
 
-		nvim, err := startNvim(width, height, socketPath, vaultPath)
+		nvim, err := startNvim(width, height, socketPath, vaultPath, tsParsers)
 		if err != nil {
 			return editorErrorMsg{err}
 		}

--- a/internal/editor/nvim_init.lua
+++ b/internal/editor/nvim_init.lua
@@ -58,6 +58,16 @@ vim.keymap.set("i", "<M-BS>", "<C-w>", { noremap = true })
 vim.keymap.set("i", "<M-Left>", "<C-Left>", { noremap = true })
 vim.keymap.set("i", "<M-Right>", "<C-Right>", { noremap = true })
 
+-- Treesitter: load extra parsers from user-configured path (treesitter_parsers).
+-- This lets Kopr syntax-highlight fenced code blocks for languages beyond the
+-- handful bundled with Neovim (c, lua, markdown, vim, vimdoc, query).
+do
+    local parsers_path = os.getenv("KOPR_TREESITTER_PARSERS")
+    if parsers_path and parsers_path ~= "" then
+        vim.opt.runtimepath:prepend(parsers_path)
+    end
+end
+
 -- Markdown-specific settings
 vim.api.nvim_create_autocmd("FileType", {
     pattern = "markdown",
@@ -65,6 +75,8 @@ vim.api.nvim_create_autocmd("FileType", {
         vim.opt_local.shiftwidth = 2
         vim.opt_local.tabstop = 2
         vim.opt_local.conceallevel = 2
+        -- Enable treesitter highlighting (syntax-highlights fenced code blocks).
+        pcall(vim.treesitter.start)
     end,
 })
 

--- a/internal/editor/pty.go
+++ b/internal/editor/pty.go
@@ -15,12 +15,16 @@ type nvimPTY struct {
 	socket string
 }
 
-func startNvim(width, height int, socketPath, vaultPath string) (*nvimPTY, error) {
+func startNvim(width, height int, socketPath, vaultPath, treesitterParsers string) (*nvimPTY, error) {
 	cmd := exec.Command("nvim",
 		"--listen", socketPath,
 	)
 	cmd.Dir = vaultPath
-	cmd.Env = append(os.Environ(), NvimEnv()...)
+	env := append(os.Environ(), NvimEnv()...)
+	if treesitterParsers != "" {
+		env = append(env, "KOPR_TREESITTER_PARSERS="+treesitterParsers)
+	}
+	cmd.Env = env
 
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{
 		Rows: uint16(height),


### PR DESCRIPTION
## Summary

- Enable `vim.treesitter.start()` on markdown buffers so fenced code blocks get syntax highlighting
- Add `treesitter_parsers` config option to load additional parsers from an external directory (e.g. `~/.local/share/nvim/site`)
- Neovim bundles parsers for c, lua, markdown, vim, vimdoc, query; the config option enables highlighting for all other languages

## Config

```toml
# Point to a directory with compiled treesitter parsers (.so files)
treesitter_parsers = "~/.local/share/nvim/site"
```

## Test plan

- [ ] `make build && make test && make lint` pass
- [ ] Launch kopr, open a note with a fenced code block using a bundled language (e.g. `lua`), confirm highlighting
- [ ] Set `treesitter_parsers` in config.toml, open a note with `python`/`bash` block, confirm highlighting
- [ ] Without `treesitter_parsers` set, non-bundled languages render as plain text (no crash)

Closes #39