### PR TITLE
mouse: click-to-focus, context menus, and double-click

### DIFF
--- a/cmd/kopr/main.go
+++ b/cmd/kopr/main.go
@@ -114,7 +114,7 @@ func runLocal(cfg config.Config) {
 
 	a := app.New(cfg)
 	a.SetOutput(os.Stdout)
-	p := tea.NewProgram(&a, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	p := tea.NewProgram(&a, tea.WithAltScreen(), tea.WithMouseAllMotion())
 	a.SetProgram(p)
 	if _, err := p.Run(); err != nil {
 		log.Fatal(err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -46,7 +46,8 @@ type App struct {
 	status   panel.Status
 	whichKey panel.WhichKey
 	finder   panel.Finder
-	prompt   panel.Prompt
+	prompt      panel.Prompt
+	contextMenu panel.ContextMenu
 	vault    *vault.Vault
 	db       *index.DB
 	indexer  *index.Indexer
@@ -77,6 +78,19 @@ type App struct {
 	// output is the terminal writer for OSC 52 clipboard sequences.
 	// os.Stdout for local mode, the SSH session for SSH mode.
 	output io.Writer
+
+	// clipboardText is an internal clipboard buffer populated on every yank.
+	// Used for context menu paste since we can't read the remote clipboard.
+	clipboardText string
+
+	// doubleClick tracks timing/position for double-click detection.
+	doubleClick doubleClickTracker
+
+	// contextMenuTreeIdx stores the tree entry index that was right-clicked.
+	contextMenuTreeIdx int
+
+	// contextMenuInfoIdx stores the info row index that was right-clicked.
+	contextMenuInfoIdx int
 }
 
 // navigateTo opens a note and updates the navigation history.
@@ -112,7 +126,8 @@ func New(cfg config.Config) App {
 		status:   panel.NewStatus(cfg.VaultPath),
 		whichKey: panel.NewWhichKey(),
 		finder:   f,
-		prompt:   panel.NewPrompt(),
+		prompt:      panel.NewPrompt(),
+		contextMenu: panel.NewContextMenu(),
 		vault:    v,
 		store:    store,
 		theme:    theme.DefaultTheme(),
@@ -128,6 +143,7 @@ func New(cfg config.Config) App {
 	a.status.SetTheme(&a.theme)
 	a.whichKey.SetTheme(&a.theme)
 	a.editor.SetTheme(&a.theme)
+	a.contextMenu.SetTheme(&a.theme)
 
 	// Initialize index
 	dbPath := filepath.Join(cfg.VaultPath, ".kopr", "index.db")
@@ -179,6 +195,7 @@ func (a *App) Init() tea.Cmd {
 func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case editor.YankMsg:
+		a.clipboardText = msg.Text
 		return a, a.writeClipboard(msg.Text)
 
 	case tea.KeyMsg:
@@ -216,6 +233,11 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return a, nil
 		}
 
+		// Ctrl+Shift+C to copy visual selection
+		if msg.String() == "ctrl+shift+c" && a.focused == focusEditor && !a.editor.ShowSplash() {
+			return a, a.copySelectedText()
+		}
+
 		// Ctrl+h/l to switch panel focus
 		switch msg.String() {
 		case "ctrl+h":
@@ -248,6 +270,143 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.focused == focusTree || a.focused == focusInfo {
 			break
 		}
+
+	case tea.MouseMsg:
+		// Dismiss context menu on click outside it (only on press, not motion/release)
+		if a.contextMenu.Visible() {
+			cx, cy := a.contextMenu.Position()
+			cw, ch := a.contextMenu.Dimensions()
+			inside := msg.X >= cx && msg.X < cx+cw && msg.Y >= cy && msg.Y < cy+ch
+			if inside {
+				// Translate to menu-local coordinates and forward
+				localMsg := msg
+				localMsg.X = msg.X - cx
+				localMsg.Y = msg.Y - cy
+				var cmd tea.Cmd
+				a.contextMenu, cmd = a.contextMenu.Update(localMsg)
+				return a, cmd
+			}
+			// Only dismiss on press outside, not on motion/release
+			if msg.Action == tea.MouseActionPress {
+				a.contextMenu.Hide()
+			}
+			return a, nil
+		}
+
+		hit := a.hitTestMouse(msg)
+		switch hit.target {
+		case mouseTargetEditor:
+			// Left press: focus editor + double-click detection
+			if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
+				a.setFocus(focusEditor)
+			}
+
+			// Right-click on editor: show text operations context menu
+			if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonRight {
+				hasFile := a.currentFile != ""
+				a.contextMenu.Show(hit.screenX, hit.screenY, []panel.ContextMenuItem{
+					{Label: "Cut", Action: "text-cut", Disabled: !hasFile},
+					{Label: "Copy", Action: "text-copy", Disabled: !hasFile},
+					{Label: "Paste", Action: "text-paste", Disabled: !hasFile},
+					{Label: "Select All", Action: "text-select-all", Disabled: !hasFile},
+				})
+				return a, nil
+			}
+
+			// Filter no-button motion (hover) from being forwarded to Neovim
+			if msg.Action == tea.MouseActionMotion && msg.Button == tea.MouseButtonNone {
+				return a, nil
+			}
+
+			// Forward other mouse events to editor (left click, scroll, drag)
+			if hit.editorRow >= 0 {
+				editorMsg := editor.EditorMouseMsg{
+					MouseMsg: msg,
+					Col:      hit.editorCol,
+					Row:      hit.editorRow,
+				}
+				a.editor, _ = a.editor.Update(editorMsg)
+			}
+			return a, nil
+
+		case mouseTargetTree:
+			if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
+				a.setFocus(focusTree)
+				// Move tree cursor to clicked row
+				rowIdx := msg.Y - 1 + a.tree.Offset()
+				a.tree.SetCursor(rowIdx)
+
+				// Double-click: open file or toggle dir
+				if a.doubleClick.isDoubleClick(msg.X, msg.Y) {
+					if entry, ok := a.tree.EntryAt(rowIdx); ok {
+						if !entry.IsDir {
+							return a, func() tea.Msg {
+								return panel.FileSelectedMsg{Path: entry.Path}
+							}
+						}
+						// Toggle collapsed dir handled by SetCursor + enter-like behavior
+						a.tree.ToggleCollapse(entry.Path)
+					}
+				}
+				return a, nil
+			}
+			// Right-click on tree: show file operations context menu
+			if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonRight {
+				a.setFocus(focusTree)
+				rowIdx := msg.Y - 1 + a.tree.Offset()
+				a.tree.SetCursor(rowIdx)
+				a.contextMenuTreeIdx = rowIdx
+
+				entry, hasEntry := a.tree.EntryAt(rowIdx)
+				isFile := hasEntry && !entry.IsDir
+				a.contextMenu.Show(hit.screenX, hit.screenY, []panel.ContextMenuItem{
+					{Label: "Open", Action: "tree-open", Disabled: !isFile},
+					{Label: "New Note", Action: "tree-new"},
+					{Label: "Rename", Action: "tree-rename", Disabled: !isFile},
+					{Label: "Delete", Action: "tree-delete", Disabled: !hasEntry},
+				})
+				return a, nil
+			}
+			return a, nil
+
+		case mouseTargetInfo:
+			if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonLeft {
+				a.setFocus(focusInfo)
+				// Move info cursor to clicked row
+				rowIdx := msg.Y - 1 + a.info.Offset()
+				a.info.SetCursor(rowIdx)
+
+				// Double-click: activate the row
+				if a.doubleClick.isDoubleClick(msg.X, msg.Y) {
+					return a, a.info.ActivateRow(rowIdx)
+				}
+				return a, nil
+			}
+			// Right-click on info: show link/heading context menu
+			if msg.Action == tea.MouseActionPress && msg.Button == tea.MouseButtonRight {
+				a.setFocus(focusInfo)
+				rowIdx := msg.Y - 1 + a.info.Offset()
+				a.info.SetCursor(rowIdx)
+				a.contextMenuInfoIdx = rowIdx
+
+				var items []panel.ContextMenuItem
+				items = append(items, panel.ContextMenuItem{Label: "Open", Action: "info-open"})
+				items = append(items, panel.ContextMenuItem{Label: "Go to", Action: "info-goto"})
+				a.contextMenu.Show(hit.screenX, hit.screenY, items)
+				return a, nil
+			}
+			return a, nil
+
+		case mouseTargetStatus:
+			return a, nil
+		}
+		return a, nil
+
+	case panel.ContextMenuResultMsg:
+		return a, a.handleContextMenuResult(msg.Action)
+
+	case panel.ContextMenuClosedMsg:
+		return a, nil
 
 	case leaderTimeoutMsg:
 		a.handleLeaderTimeout()
@@ -421,6 +580,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.status.SetTheme(&a.theme)
 			a.whichKey.SetTheme(&a.theme)
 			a.editor.SetTheme(&a.theme)
+			a.contextMenu.SetTheme(&a.theme)
 		}
 		return a, nil
 
@@ -567,6 +727,15 @@ func (a *App) View() string {
 		promptView := a.prompt.View()
 		if promptView != "" {
 			result = overlayCenter(result, promptView, a.width, a.height)
+		}
+	}
+
+	// Overlay context menu
+	if a.contextMenu.Visible() {
+		menuView := a.contextMenu.View()
+		if menuView != "" {
+			cx, cy := a.contextMenu.Position()
+			result = overlayAt(result, menuView, cx, cy, a.width, a.height)
 		}
 	}
 
@@ -1112,6 +1281,103 @@ func (a *App) handleRenameNote(newName, oldPath string) tea.Cmd {
 	return nil
 }
 
+// handleContextMenuResult dispatches context menu actions to the appropriate handlers.
+func (a *App) handleContextMenuResult(action string) tea.Cmd {
+	switch action {
+	// Editor text operations
+	case "text-cut":
+		return a.cutSelectedText()
+	case "text-copy":
+		return a.copySelectedText()
+	case "text-paste":
+		return a.pasteFromClipboard()
+	case "text-select-all":
+		return a.selectAllText()
+
+	// Tree file operations
+	case "tree-open":
+		if entry, ok := a.tree.EntryAt(a.contextMenuTreeIdx); ok && !entry.IsDir {
+			return func() tea.Msg { return panel.FileSelectedMsg{Path: entry.Path} }
+		}
+	case "tree-new":
+		return func() tea.Msg { return panel.TreeNewNoteMsg{} }
+	case "tree-rename":
+		if entry, ok := a.tree.EntryAt(a.contextMenuTreeIdx); ok && !entry.IsDir {
+			return func() tea.Msg {
+				return panel.TreeRenameNoteMsg{Path: entry.Path, Name: entry.Name}
+			}
+		}
+	case "tree-delete":
+		if entry, ok := a.tree.EntryAt(a.contextMenuTreeIdx); ok {
+			path := entry.Path
+			name := entry.Name
+			return func() tea.Msg {
+				return panel.TreeDeleteNoteMsg{Path: path, Name: name}
+			}
+		}
+
+	// Info panel operations
+	case "info-open", "info-goto":
+		return a.info.ActivateRow(a.contextMenuInfoIdx)
+	}
+	return nil
+}
+
+// copySelectedText copies the visual selection to the clipboard.
+func (a *App) copySelectedText() tea.Cmd {
+	rpc := a.editor.GetRPC()
+	if rpc == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		text, err := rpc.GetVisualSelection()
+		if err != nil || text == "" {
+			return nil
+		}
+		return editor.YankMsg{Text: text}
+	}
+}
+
+// cutSelectedText cuts the visual selection and copies it to the clipboard.
+func (a *App) cutSelectedText() tea.Cmd {
+	rpc := a.editor.GetRPC()
+	if rpc == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		text, err := rpc.CutSelection()
+		if err != nil || text == "" {
+			return nil
+		}
+		return editor.YankMsg{Text: text}
+	}
+}
+
+// pasteFromClipboard pastes the internal clipboard text into the editor.
+func (a *App) pasteFromClipboard() tea.Cmd {
+	rpc := a.editor.GetRPC()
+	if rpc == nil || a.clipboardText == "" {
+		return nil
+	}
+	text := a.clipboardText
+	return func() tea.Msg {
+		rpc.PasteText(text) //nolint:errcheck // best-effort paste
+		return nil
+	}
+}
+
+// selectAllText selects all text in the editor.
+func (a *App) selectAllText() tea.Cmd {
+	rpc := a.editor.GetRPC()
+	if rpc == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		rpc.SelectAll() //nolint:errcheck // best-effort select all
+		return nil
+	}
+}
+
 func (a *App) panelsVisible() (bool, bool) {
 	splash := a.editor.ShowSplash()
 	return a.showTree && !a.zenMode && !splash, a.showInfo && !a.zenMode && !splash
@@ -1302,6 +1568,60 @@ func overlayCenter(base, overlay string, width, height int) string {
 
 		line := left + overlayLine + right
 		// Ensure line doesn't overflow terminal width.
+		baseLines[row] = ansi.Truncate(line, width, "")
+	}
+
+	return strings.Join(baseLines, "\n")
+}
+
+// overlayAt renders an overlay string on top of base at the given screen position.
+// The overlay is clamped so it stays within width x height bounds.
+func overlayAt(base, overlay string, x, y, width, height int) string {
+	baseLines := strings.Split(base, "\n")
+	overlayLines := strings.Split(overlay, "\n")
+
+	overlayWidth := 0
+	for _, line := range overlayLines {
+		w := lipgloss.Width(line)
+		if w > overlayWidth {
+			overlayWidth = w
+		}
+	}
+
+	// Clamp position so the menu stays on screen
+	if x+overlayWidth > width {
+		x = width - overlayWidth
+	}
+	if x < 0 {
+		x = 0
+	}
+	if y+len(overlayLines) > height {
+		y = height - len(overlayLines)
+	}
+	if y < 0 {
+		y = 0
+	}
+
+	padToCol := func(s string, col int) string {
+		for lipgloss.Width(s) < col {
+			s += " "
+		}
+		return s
+	}
+
+	for i, overlayLine := range overlayLines {
+		row := y + i
+		if row >= len(baseLines) {
+			break
+		}
+
+		baseLine := baseLines[row]
+		baseLine = padToCol(baseLine, x)
+
+		left := ansi.Cut(baseLine, 0, x)
+		right := ansi.Cut(baseLine, x+overlayWidth, width)
+
+		line := left + overlayLine + right
 		baseLines[row] = ansi.Truncate(line, width, "")
 	}
 

--- a/internal/app/mouse.go
+++ b/internal/app/mouse.go
@@ -1,6 +1,36 @@
 package app
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// doubleClickTracker detects double-clicks based on timing and position.
+type doubleClickTracker struct {
+	lastTime time.Time
+	lastX    int
+	lastY    int
+}
+
+// isDoubleClick returns true if (x, y) is a double-click relative to the
+// previous click. A double-click must occur within 500ms and within 2 cells.
+func (d *doubleClickTracker) isDoubleClick(x, y int) bool {
+	now := time.Now()
+	dx := x - d.lastX
+	dy := y - d.lastY
+	if dx < 0 {
+		dx = -dx
+	}
+	if dy < 0 {
+		dy = -dy
+	}
+	dbl := now.Sub(d.lastTime) < 500*time.Millisecond && dx <= 2 && dy <= 2
+	d.lastTime = now
+	d.lastX = x
+	d.lastY = y
+	return dbl
+}
 
 // mouseTarget identifies which panel a mouse event landed in.
 type mouseTarget int

--- a/internal/app/mouse.go
+++ b/internal/app/mouse.go
@@ -1,0 +1,82 @@
+package app
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// mouseTarget identifies which panel a mouse event landed in.
+type mouseTarget int
+
+const (
+	mouseTargetNone   mouseTarget = iota
+	mouseTargetTree
+	mouseTargetEditor
+	mouseTargetInfo
+	mouseTargetStatus
+)
+
+// mouseHitResult contains the result of hit-testing a mouse event.
+type mouseHitResult struct {
+	target mouseTarget
+
+	// editorCol and editorRow are 0-based coordinates relative to the
+	// Neovim buffer area. Only valid when target == mouseTargetEditor
+	// and editorRow >= 0.
+	editorCol int
+	editorRow int // -1 when click is on the editor title row
+
+	// screenX and screenY are the original screen coordinates.
+	screenX int
+	screenY int
+}
+
+// hitTestMouse determines which panel a mouse event lands in and translates
+// coordinates for the editor panel.
+func (a *App) hitTestMouse(msg tea.MouseMsg) mouseHitResult {
+	showTree, showInfo := a.panelsVisible()
+	layout := ComputeLayout(a.width, a.height, showTree, showInfo, a.cfg.TreeWidth, a.cfg.InfoWidth)
+
+	result := mouseHitResult{
+		screenX: msg.X,
+		screenY: msg.Y,
+	}
+
+	// Status bar occupies the last row(s)
+	if msg.Y >= layout.Height {
+		result.target = mouseTargetStatus
+		return result
+	}
+
+	// Determine editor column boundaries
+	editorStartX := 0
+	if showTree {
+		// Tree occupies columns [0, TreeWidth). Content is TreeWidth-1 wide
+		// plus a 1-char right border, totaling TreeWidth columns.
+		if msg.X < layout.TreeWidth {
+			result.target = mouseTargetTree
+			return result
+		}
+		editorStartX = layout.TreeWidth
+	}
+
+	if showInfo {
+		// Info panel starts after the editor column.
+		infoStartX := editorStartX + layout.EditorWidth
+		if msg.X >= infoStartX {
+			result.target = mouseTargetInfo
+			return result
+		}
+	}
+
+	// Everything else falls in the editor column
+	result.target = mouseTargetEditor
+	result.editorCol = msg.X - editorStartX
+
+	// Row 0 of the editor area is the title row.
+	// Neovim buffer content starts at row 1.
+	if msg.Y < 1 {
+		result.editorRow = -1 // title row
+	} else {
+		result.editorRow = msg.Y - 1
+	}
+
+	return result
+}

--- a/internal/app/mouse_test.go
+++ b/internal/app/mouse_test.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/pfassina/kopr/internal/config"
+)
+
+func newMouseMsg(x, y int) tea.MouseMsg {
+	return tea.MouseMsg{X: x, Y: y}
+}
+
+func TestHitTestMouse(t *testing.T) {
+	// 100 wide, 30 tall, tree=25, info=25.
+	// With both panels visible:
+	//   Tree:   cols 0-24  (25 wide including border)
+	//   Editor: cols 25-76 (EditorWidth = 100 - 24 - 24 = 52)
+	//   Info:   cols 77-99
+	//   Status: row 29
+	//   Editor title: row 0
+	//   Neovim buffer: rows 1-28
+	cfg := config.Config{
+		TreeWidth: 25,
+		InfoWidth: 25,
+	}
+	a := App{
+		cfg:      cfg,
+		width:    100,
+		height:   30,
+		showTree: true,
+		showInfo: true,
+	}
+
+	tests := []struct {
+		name      string
+		x, y      int
+		target    mouseTarget
+		editorCol int
+		editorRow int
+	}{
+		{
+			name:   "tree click",
+			x:      10,
+			y:      5,
+			target: mouseTargetTree,
+		},
+		{
+			name:   "tree border click",
+			x:      24,
+			y:      5,
+			target: mouseTargetTree,
+		},
+		{
+			name:      "editor title row",
+			x:         30,
+			y:         0,
+			target:    mouseTargetEditor,
+			editorCol: 5,
+			editorRow: -1,
+		},
+		{
+			name:      "editor content click",
+			x:         35,
+			y:         5,
+			target:    mouseTargetEditor,
+			editorCol: 10,
+			editorRow: 4,
+		},
+		{
+			name:      "editor first content row",
+			x:         25,
+			y:         1,
+			target:    mouseTargetEditor,
+			editorCol: 0,
+			editorRow: 0,
+		},
+		{
+			name:   "info panel click",
+			x:      80,
+			y:      5,
+			target: mouseTargetInfo,
+		},
+		{
+			name:   "status bar click",
+			x:      50,
+			y:      29,
+			target: mouseTargetStatus,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := a.hitTestMouse(newMouseMsg(tt.x, tt.y))
+			if result.target != tt.target {
+				t.Errorf("target: got %d, want %d", result.target, tt.target)
+			}
+			if tt.target == mouseTargetEditor {
+				if result.editorCol != tt.editorCol {
+					t.Errorf("editorCol: got %d, want %d", result.editorCol, tt.editorCol)
+				}
+				if result.editorRow != tt.editorRow {
+					t.Errorf("editorRow: got %d, want %d", result.editorRow, tt.editorRow)
+				}
+			}
+		})
+	}
+}
+
+func TestHitTestMouseNoSidePanels(t *testing.T) {
+	cfg := config.Config{
+		TreeWidth: 25,
+		InfoWidth: 25,
+	}
+	a := App{
+		cfg:    cfg,
+		width:  100,
+		height: 30,
+	}
+
+	result := a.hitTestMouse(newMouseMsg(50, 10))
+	if result.target != mouseTargetEditor {
+		t.Errorf("target: got %d, want mouseTargetEditor", result.target)
+	}
+	if result.editorCol != 50 {
+		t.Errorf("editorCol: got %d, want 50", result.editorCol)
+	}
+	if result.editorRow != 9 {
+		t.Errorf("editorRow: got %d, want 9", result.editorRow)
+	}
+}
+
+func TestHitTestMouseTreeOnlyNoInfo(t *testing.T) {
+	cfg := config.Config{
+		TreeWidth: 25,
+		InfoWidth: 25,
+	}
+	a := App{
+		cfg:      cfg,
+		width:    100,
+		height:   30,
+		showTree: true,
+	}
+
+	result := a.hitTestMouse(newMouseMsg(90, 5))
+	if result.target != mouseTargetEditor {
+		t.Errorf("target: got %d, want mouseTargetEditor", result.target)
+	}
+	if result.editorCol != 65 {
+		t.Errorf("editorCol: got %d, want 65", result.editorCol)
+	}
+}

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -86,8 +86,9 @@ type Editor struct {
 	mode        NvimMode
 	err         error
 	program     *tea.Program
-	focused     bool
-	showSplash  bool
+	focused        bool
+	showSplash     bool
+	lastMouseButton tea.MouseButton
 }
 
 // SetTheme sets the color theme for the editor splash screen.
@@ -236,6 +237,11 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 				return e, tea.Quit
 			}
 		}
+		// Enable mouse support so Neovim processes mouse events from the PTY
+		if err := e.rpc.ExecCommand("set mouse=a"); err != nil {
+			e.err = err
+			return e, tea.Quit
+		}
 		// Ensure left gutter aligns buffer text with panel titles
 		if err := e.rpc.ExecCommand("set foldcolumn=1"); err != nil {
 			e.err = err
@@ -276,6 +282,26 @@ func (e Editor) Update(msg tea.Msg) (Editor, tea.Cmd) {
 	case vtClosedMsg:
 		debugf("vtClosedMsg: %v", msg.err)
 		return e, tea.Quit
+
+	case EditorMouseMsg:
+		if e.nvim == nil || e.showSplash {
+			return e, nil
+		}
+		// Track pressed button so we can encode releases correctly
+		if msg.Action == tea.MouseActionPress {
+			e.lastMouseButton = msg.Button
+		}
+		raw := mouseMsgToBytes(msg.MouseMsg, msg.Col, msg.Row, e.lastMouseButton)
+		if raw != nil {
+			if _, err := e.nvim.file.Write(raw); err != nil {
+				e.err = err
+				return e, tea.Quit
+			}
+		}
+		if msg.Action == tea.MouseActionRelease {
+			e.lastMouseButton = tea.MouseButtonNone
+		}
+		return e, nil
 
 	case tea.KeyMsg:
 		if e.nvim == nil || e.showSplash {

--- a/internal/editor/mouse.go
+++ b/internal/editor/mouse.go
@@ -1,0 +1,82 @@
+package editor
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// EditorMouseMsg is a mouse event with coordinates already translated
+// to the Neovim buffer area (0-based).
+type EditorMouseMsg struct {
+	tea.MouseMsg
+	Col int // 0-based column relative to Neovim
+	Row int // 0-based row relative to Neovim
+}
+
+// mouseMsgToBytes converts a Bubble Tea mouse message to SGR 1006 escape
+// sequences suitable for writing to a Neovim PTY.
+// col and row are 0-based coordinates relative to the Neovim buffer area.
+// Returns nil if the event cannot be translated.
+func mouseMsgToBytes(msg tea.MouseMsg, col, row int, lastButton tea.MouseButton) []byte {
+	var button int
+	switch msg.Button {
+	case tea.MouseButtonLeft:
+		button = 0
+	case tea.MouseButtonMiddle:
+		button = 1
+	case tea.MouseButtonRight:
+		button = 2
+	case tea.MouseButtonWheelUp:
+		button = 64
+	case tea.MouseButtonWheelDown:
+		button = 65
+	case tea.MouseButtonWheelLeft:
+		button = 66
+	case tea.MouseButtonWheelRight:
+		button = 67
+	case tea.MouseButtonNone:
+		// On release, Bubble Tea reports MouseButtonNone.
+		// Use the last pressed button to encode the release correctly.
+		switch lastButton {
+		case tea.MouseButtonLeft:
+			button = 0
+		case tea.MouseButtonMiddle:
+			button = 1
+		case tea.MouseButtonRight:
+			button = 2
+		default:
+			button = 0
+		}
+	default:
+		return nil
+	}
+
+	// Add motion flag for drag events
+	if msg.Action == tea.MouseActionMotion {
+		button |= 32
+	}
+
+	// Modifier flags
+	if msg.Shift {
+		button |= 4
+	}
+	if msg.Alt {
+		button |= 8
+	}
+	if msg.Ctrl {
+		button |= 16
+	}
+
+	// SGR uses 1-based coordinates
+	sgrCol := col + 1
+	sgrRow := row + 1
+
+	// Suffix: 'M' for press/motion, 'm' for release
+	suffix := 'M'
+	if msg.Action == tea.MouseActionRelease {
+		suffix = 'm'
+	}
+
+	return fmt.Appendf(nil, "\x1b[<%d;%d;%d%c", button, sgrCol, sgrRow, suffix)
+}

--- a/internal/editor/mouse_test.go
+++ b/internal/editor/mouse_test.go
@@ -1,0 +1,117 @@
+package editor
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestMouseMsgToBytes(t *testing.T) {
+	tests := []struct {
+		name       string
+		msg        tea.MouseMsg
+		col        int
+		row        int
+		lastButton tea.MouseButton
+		want       string
+	}{
+		{
+			name:       "left press at origin",
+			msg:        tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft},
+			col:        0,
+			row:        0,
+			lastButton: tea.MouseButtonNone,
+			want:       "\x1b[<0;1;1M",
+		},
+		{
+			name:       "left release at 5,10",
+			msg:        tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonNone},
+			col:        5,
+			row:        10,
+			lastButton: tea.MouseButtonLeft,
+			want:       "\x1b[<0;6;11m",
+		},
+		{
+			name:       "right press at 3,7",
+			msg:        tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonRight},
+			col:        3,
+			row:        7,
+			lastButton: tea.MouseButtonNone,
+			want:       "\x1b[<2;4;8M",
+		},
+		{
+			name:       "left drag at 10,5",
+			msg:        tea.MouseMsg{Action: tea.MouseActionMotion, Button: tea.MouseButtonLeft},
+			col:        10,
+			row:        5,
+			lastButton: tea.MouseButtonLeft,
+			want:       "\x1b[<32;11;6M",
+		},
+		{
+			name:       "scroll up",
+			msg:        tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp},
+			col:        0,
+			row:        0,
+			lastButton: tea.MouseButtonNone,
+			want:       "\x1b[<64;1;1M",
+		},
+		{
+			name:       "scroll down",
+			msg:        tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown},
+			col:        2,
+			row:        3,
+			lastButton: tea.MouseButtonNone,
+			want:       "\x1b[<65;3;4M",
+		},
+		{
+			name: "ctrl+left press",
+			msg: tea.MouseMsg{
+				Action: tea.MouseActionPress,
+				Button: tea.MouseButtonLeft,
+				Ctrl:   true,
+			},
+			col:        0,
+			row:        0,
+			lastButton: tea.MouseButtonNone,
+			want:       "\x1b[<16;1;1M",
+		},
+		{
+			name:       "middle press",
+			msg:        tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonMiddle},
+			col:        1,
+			row:        1,
+			lastButton: tea.MouseButtonNone,
+			want:       "\x1b[<1;2;2M",
+		},
+		{
+			name:       "right release uses lastButton",
+			msg:        tea.MouseMsg{Action: tea.MouseActionRelease, Button: tea.MouseButtonNone},
+			col:        4,
+			row:        6,
+			lastButton: tea.MouseButtonRight,
+			want:       "\x1b[<2;5;7m",
+		},
+		{
+			name:       "unsupported button returns nil",
+			msg:        tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonBackward},
+			col:        0,
+			row:        0,
+			lastButton: tea.MouseButtonNone,
+			want:       "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mouseMsgToBytes(tt.msg, tt.col, tt.row, tt.lastButton)
+			if tt.want == "" {
+				if got != nil {
+					t.Errorf("got %q, want nil", string(got))
+				}
+				return
+			}
+			if string(got) != tt.want {
+				t.Errorf("got %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}

--- a/internal/editor/rpc.go
+++ b/internal/editor/rpc.go
@@ -602,6 +602,48 @@ if vim.bo[buf].filetype == 'markdown' then
 end
 `
 
+// GetVisualSelection returns the text currently selected in visual mode.
+// If not in a visual mode, returns an empty string.
+func (r *RPC) GetVisualSelection() (string, error) {
+	var text string
+	err := r.client.ExecLua(`
+local mode = vim.fn.mode()
+if mode ~= 'v' and mode ~= 'V' and mode ~= '\22' then
+  return ''
+end
+-- Yank the selection into the unnamed register, then restore mode
+vim.cmd('normal! y')
+return vim.fn.getreg('"')
+`, &text)
+	return text, err
+}
+
+// CutSelection yanks the visual selection text and deletes it.
+func (r *RPC) CutSelection() (string, error) {
+	var text string
+	err := r.client.ExecLua(`
+local mode = vim.fn.mode()
+if mode ~= 'v' and mode ~= 'V' and mode ~= '\22' then
+  return ''
+end
+vim.cmd('normal! y')
+local t = vim.fn.getreg('"')
+vim.cmd('normal! gvd')
+return t
+`, &text)
+	return text, err
+}
+
+// PasteText pastes text at the current cursor position using Neovim's paste API.
+func (r *RPC) PasteText(text string) error {
+	return r.client.ExecLua("vim.api.nvim_paste(..., true, -1)", nil, text)
+}
+
+// SelectAll selects all text in the current buffer.
+func (r *RPC) SelectAll() error {
+	return r.client.Command("normal! ggVG")
+}
+
 // Close closes the RPC connection.
 func (r *RPC) Close() error {
 	if r.client != nil {

--- a/internal/panel/contextmenu.go
+++ b/internal/panel/contextmenu.go
@@ -1,0 +1,219 @@
+package panel
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/pfassina/kopr/internal/theme"
+)
+
+// ContextMenuItem represents a single menu entry.
+type ContextMenuItem struct {
+	Label    string
+	Action   string // identifier (e.g., "cut", "copy", "paste")
+	Disabled bool
+}
+
+// ContextMenuResultMsg is sent when a context menu item is selected.
+type ContextMenuResultMsg struct {
+	Action string
+}
+
+// ContextMenuClosedMsg is sent when the context menu is dismissed.
+type ContextMenuClosedMsg struct{}
+
+// ContextMenu is a right-click popup menu.
+type ContextMenu struct {
+	items      []ContextMenuItem
+	cursor     int
+	x          int // screen position (column)
+	y          int // screen position (row)
+	visible    bool
+	theme      *theme.Theme
+	width      int  // computed in Show() from item labels
+	height     int  // computed in Show() from item count
+	mouseMoved bool // true once the cursor changes via mouse motion (for hold-and-drag)
+}
+
+// NewContextMenu creates a new context menu.
+func NewContextMenu() ContextMenu {
+	return ContextMenu{}
+}
+
+// SetTheme sets the color theme.
+func (c *ContextMenu) SetTheme(th *theme.Theme) { c.theme = th }
+
+// Show displays the context menu at the given screen position.
+func (c *ContextMenu) Show(x, y int, items []ContextMenuItem) {
+	c.x = x
+	c.y = y
+	c.items = items
+	c.visible = true
+	c.mouseMoved = false
+
+	// Start cursor on the first non-disabled item
+	c.cursor = 0
+	for i, item := range items {
+		if !item.Disabled {
+			c.cursor = i
+			break
+		}
+	}
+
+	// Pre-compute dimensions to match View() output.
+	// View renders: border(1) + padding(1) + content + padding(1) + border(1)
+	// Height: border(1) + items + border(1)
+	maxLabelW := 0
+	for _, item := range items {
+		w := len(item.Label) + 2 // "> " or "  " prefix
+		if w > maxLabelW {
+			maxLabelW = w
+		}
+	}
+	c.width = maxLabelW + 4  // 2 border + 2 padding
+	c.height = len(items) + 2 // 2 border
+}
+
+// Hide dismisses the context menu.
+func (c *ContextMenu) Hide() {
+	c.visible = false
+}
+
+// Visible reports whether the context menu is showing.
+func (c ContextMenu) Visible() bool {
+	return c.visible
+}
+
+// Position returns the screen position for overlay rendering.
+func (c ContextMenu) Position() (x, y int) {
+	return c.x, c.y
+}
+
+// Dimensions returns the width and height of the menu.
+func (c ContextMenu) Dimensions() (w, h int) {
+	return c.width, c.height
+}
+
+// Update handles key and mouse events for the context menu.
+func (c ContextMenu) Update(msg tea.Msg) (ContextMenu, tea.Cmd) {
+	if !c.visible {
+		return c, nil
+	}
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "esc", "q":
+			c.visible = false
+			return c, func() tea.Msg { return ContextMenuClosedMsg{} }
+		case "j", "down":
+			c.moveCursorDown()
+		case "k", "up":
+			c.moveCursorUp()
+		case "enter":
+			if c.cursor < len(c.items) && !c.items[c.cursor].Disabled {
+				action := c.items[c.cursor].Action
+				c.visible = false
+				return c, func() tea.Msg {
+					return ContextMenuResultMsg{Action: action}
+				}
+			}
+		}
+
+	case tea.MouseMsg:
+		// The menu is rendered with a border (1 char top/bottom) and
+		// padding (1 char left/right). Item rows start at local row 1
+		// (after top border) and occupy one row each.
+		// msg.X and msg.Y are menu-local coordinates set by the app layer.
+		itemRow := msg.Y - 1 // subtract top border
+
+		switch msg.Action {
+		case tea.MouseActionMotion:
+			if itemRow >= 0 && itemRow < len(c.items) && !c.items[itemRow].Disabled {
+				if c.cursor != itemRow {
+					c.mouseMoved = true
+				}
+				c.cursor = itemRow
+			}
+		case tea.MouseActionPress:
+			if msg.Button == tea.MouseButtonLeft && itemRow >= 0 && itemRow < len(c.items) && !c.items[itemRow].Disabled {
+				action := c.items[itemRow].Action
+				c.visible = false
+				return c, func() tea.Msg {
+					return ContextMenuResultMsg{Action: action}
+				}
+			}
+		case tea.MouseActionRelease:
+			// Right-click hold-and-drag: if the user moved the cursor via
+			// mouse motion (button held) and then released, select the item.
+			if c.mouseMoved && itemRow >= 0 && itemRow < len(c.items) && !c.items[itemRow].Disabled {
+				action := c.items[itemRow].Action
+				c.visible = false
+				return c, func() tea.Msg {
+					return ContextMenuResultMsg{Action: action}
+				}
+			}
+		}
+	}
+
+	return c, nil
+}
+
+func (c *ContextMenu) moveCursorDown() {
+	for i := c.cursor + 1; i < len(c.items); i++ {
+		if !c.items[i].Disabled {
+			c.cursor = i
+			return
+		}
+	}
+}
+
+func (c *ContextMenu) moveCursorUp() {
+	for i := c.cursor - 1; i >= 0; i-- {
+		if !c.items[i].Disabled {
+			c.cursor = i
+			return
+		}
+	}
+}
+
+// View renders the context menu.
+func (c ContextMenu) View() string {
+	if !c.visible || len(c.items) == 0 {
+		return ""
+	}
+
+	th := c.theme
+
+	borderStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(th.Border).
+		Padding(0, 1)
+
+	var lines []string
+	for i, item := range c.items {
+		label := item.Label
+
+		var style lipgloss.Style
+		switch {
+		case item.Disabled:
+			style = lipgloss.NewStyle().Foreground(th.Dim)
+			label = "  " + label
+		case i == c.cursor:
+			style = lipgloss.NewStyle().
+				Foreground(th.Accent).
+				Bold(true)
+			label = "> " + label
+		default:
+			style = lipgloss.NewStyle().Foreground(th.Text)
+			label = "  " + label
+		}
+
+		lines = append(lines, style.Render(label))
+	}
+
+	content := strings.Join(lines, "\n")
+	return borderStyle.Render(content)
+}

--- a/internal/panel/contextmenu_test.go
+++ b/internal/panel/contextmenu_test.go
@@ -1,0 +1,65 @@
+package panel
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/pfassina/kopr/internal/theme"
+)
+
+func TestContextMenuDimensions(t *testing.T) {
+	th := theme.DefaultTheme()
+	cm := NewContextMenu()
+	cm.SetTheme(&th)
+
+	items := []ContextMenuItem{
+		{Label: "Cut", Action: "cut"},
+		{Label: "Copy", Action: "copy"},
+		{Label: "Paste", Action: "paste"},
+		{Label: "Select All", Action: "select-all"},
+	}
+
+	cm.Show(10, 10, items)
+
+	// Verify dimensions computed in Show() match actual rendered output
+	rendered := cm.View()
+	renderedW := lipgloss.Width(rendered)
+	renderedH := lipgloss.Height(rendered)
+
+	w, h := cm.Dimensions()
+	if w != renderedW {
+		t.Errorf("width: Show() computed %d, View() rendered %d", w, renderedW)
+	}
+	if h != renderedH {
+		t.Errorf("height: Show() computed %d, View() rendered %d", h, renderedH)
+	}
+}
+
+func TestContextMenuDimensionsWithDisabledItems(t *testing.T) {
+	th := theme.DefaultTheme()
+	cm := NewContextMenu()
+	cm.SetTheme(&th)
+
+	items := []ContextMenuItem{
+		{Label: "Cut", Action: "cut", Disabled: true},
+		{Label: "Copy", Action: "copy", Disabled: true},
+		{Label: "Paste", Action: "paste"},
+		{Label: "Delete", Action: "delete", Disabled: true},
+		{Label: "Select All", Action: "select-all"},
+	}
+
+	cm.Show(0, 0, items)
+
+	rendered := cm.View()
+	renderedW := lipgloss.Width(rendered)
+	renderedH := lipgloss.Height(rendered)
+
+	w, h := cm.Dimensions()
+	if w != renderedW {
+		t.Errorf("width: Show() computed %d, View() rendered %d", w, renderedW)
+	}
+	if h != renderedH {
+		t.Errorf("height: Show() computed %d, View() rendered %d", h, renderedH)
+	}
+}

--- a/internal/panel/info.go
+++ b/internal/panel/info.go
@@ -375,3 +375,61 @@ func (i *Info) SetSize(width, height int) {
 func (i *Info) SetFocused(focused bool) {
 	i.focused = focused
 }
+
+// Offset returns the current scroll offset.
+func (i Info) Offset() int {
+	return i.offset
+}
+
+// SetCursor moves the cursor to the given flat-list index, skipping separators.
+func (i *Info) SetCursor(idx int) {
+	rows := i.flatList()
+	if len(rows) == 0 {
+		return
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(rows) {
+		idx = len(rows) - 1
+	}
+	// Skip separators forward
+	for idx < len(rows) && rows[idx].kind == rowSeparator {
+		idx++
+	}
+	if idx >= len(rows) {
+		idx = len(rows) - 1
+		for idx > 0 && rows[idx].kind == rowSeparator {
+			idx--
+		}
+	}
+	i.cursor = idx
+	i.scrollIntoView()
+}
+
+// ActivateRow performs the default action for a row: open links, jump to
+// outline headings, or toggle section collapse.
+func (i *Info) ActivateRow(idx int) tea.Cmd {
+	rows := i.flatList()
+	if idx < 0 || idx >= len(rows) {
+		return nil
+	}
+	row := rows[idx]
+	switch row.kind {
+	case rowHeader:
+		i.sections[row.sectionIdx].collapsed = !i.sections[row.sectionIdx].collapsed
+		i.clampCursor()
+		return nil
+	case rowItem:
+		item := i.sections[row.sectionIdx].items[row.itemIdx]
+		if item.Path != "" {
+			path := item.Path
+			return func() tea.Msg { return FileSelectedMsg{Path: path} }
+		}
+		if item.Line > 0 {
+			line := item.Line
+			return func() tea.Msg { return InfoGotoLineMsg{Line: line} }
+		}
+	}
+	return nil
+}

--- a/internal/panel/tree.go
+++ b/internal/panel/tree.go
@@ -204,6 +204,11 @@ func (t *Tree) ClearSelected() {
 	t.selected = make(map[string]bool)
 }
 
+// SetClipboard sets the clipboard to the given paths and operation.
+func (t *Tree) SetClipboard(paths []string, op ClipboardOp) {
+	t.clipboard = Clipboard{Op: op, Paths: append([]string(nil), paths...)}
+}
+
 // ClipboardInfo returns the current clipboard operation and count.
 func (t *Tree) ClipboardInfo() (ClipboardOp, int) {
 	return t.clipboard.Op, len(t.clipboard.Paths)
@@ -521,4 +526,49 @@ func (t *Tree) SetFocused(focused bool) {
 
 func (t Tree) ShowingHelp() bool {
 	return t.showHelp
+}
+
+// Offset returns the current scroll offset.
+func (t Tree) Offset() int {
+	return t.offset
+}
+
+// EntryAt returns the entry at the given visible index, or false if out of bounds.
+func (t Tree) EntryAt(idx int) (vault.Entry, bool) {
+	if idx < 0 || idx >= len(t.entries) {
+		return vault.Entry{}, false
+	}
+	return t.entries[idx], true
+}
+
+// ToggleCollapse toggles the collapsed state of a directory entry.
+func (t *Tree) ToggleCollapse(path string) {
+	t.collapsed[path] = !t.collapsed[path]
+	t.rebuildVisible()
+}
+
+// SetCursor moves the cursor to the given index with bounds checking.
+func (t *Tree) SetCursor(idx int) {
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(t.entries) {
+		idx = len(t.entries) - 1
+	}
+	if idx < 0 {
+		idx = 0
+	}
+	t.cursor = idx
+
+	// Scroll into view
+	viewHeight := t.height - 2
+	if viewHeight < 1 {
+		viewHeight = 1
+	}
+	if t.cursor < t.offset {
+		t.offset = t.cursor
+	}
+	if t.cursor-t.offset >= viewHeight {
+		t.offset = t.cursor - viewHeight + 1
+	}
 }

--- a/internal/ssh/handler.go
+++ b/internal/ssh/handler.go
@@ -17,7 +17,7 @@ func NewHandler(cfg config.Config) bts.Handler {
 
 		opts := []tea.ProgramOption{
 			tea.WithAltScreen(),
-			tea.WithMouseCellMotion(),
+			tea.WithMouseAllMotion(),
 		}
 		opts = append(opts, bts.MakeOptions(sess)...)
 


### PR DESCRIPTION
## Summary

- Left-click any panel (tree, editor, info) to switch focus
- Right-click editor shows text operations (Cut/Copy/Paste/Select All) instead of file operations
- Right-click tree shows file operations (Open/New Note/Rename/Delete) on the clicked entry
- Right-click info shows link/heading actions (Open/Go to)
- Double-click tree entries to open files or toggle directories
- Double-click info items to follow links or jump to headings
- Hover over context menu items highlights without holding a mouse button
- Context menu only dismisses on click outside, not on mouse movement
- Ctrl+Shift+C copies the visual selection to clipboard
- Internal clipboard buffer enables context menu paste (external paste still works via Ctrl+Shift+V in insert mode)

## Test plan

- [ ] Left-click tree/info/editor switches focus border
- [ ] Right-click editor shows Cut/Copy/Paste/Select All menu
- [ ] Right-click tree shows Open/New Note/Rename/Delete menu
- [ ] Right-click info shows Open/Go to menu
- [ ] Hover over menu items highlights without holding button
- [ ] Moving mouse outside menu does not dismiss it; clicking outside does
- [ ] Select text in editor, right-click Copy, move cursor, right-click Paste
- [ ] Ctrl+Shift+C copies selected text
- [ ] Double-click file in tree opens it; double-click dir toggles collapse
- [ ] Double-click backlink/outgoing link in info opens it
- [ ] Double-click outline heading jumps cursor to that line
- [ ] Single-click in tree/info moves cursor to the clicked row